### PR TITLE
Small wifi refactor

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -4,12 +4,6 @@
 #define WIFI_MAX_SSID_LENGTH 40
 #define WIFI_MAX_PASSWORD_LENGTH 40
 
-struct WifiCredentials
-{
-  char ssid[WIFI_MAX_SSID_LENGTH];
-  char password[WIFI_MAX_PASSWORD_LENGTH];
-};
-
 typedef enum
 {
   MODE_DEFAULT,

--- a/lib/wificaptive/src/WebServer.cpp
+++ b/lib/wificaptive/src/WebServer.cpp
@@ -109,7 +109,7 @@ void setUpWebserver(AsyncWebServer &server, const IPAddress &localIP, WifiOperat
 		String ssid = data["ssid"];
 		String pswd = data["pswd"];
         String api_server = data["server"];
-        callbacks.setConnectionCredentials(ssid, pswd, api_server);
+        callbacks.setConnectionCredentials({ssid, pswd}, api_server);
         String mac = WiFi.macAddress();
         String message = "{\"ssid\":\"" + ssid + "\",\"mac\":\"" + mac + "\"}";
         request->send(200, "application/json", message); });

--- a/lib/wificaptive/src/WebServer.cpp
+++ b/lib/wificaptive/src/WebServer.cpp
@@ -1,0 +1,121 @@
+#include "WebServer.h"
+
+void setUpWebserver(AsyncWebServer &server, const IPAddress &localIP, WifiOperationCallbacks callbacks)
+{
+    //======================== Webserver ========================
+    // WARNING IOS (and maybe macos) WILL NOT POP UP IF IT CONTAINS THE WORD "Success" https://www.esp8266.com/viewtopic.php?f=34&t=4398
+    // SAFARI (IOS) IS STUPID, G-ZIPPED FILES CAN'T END IN .GZ https://github.com/homieiot/homie-esp8266/issues/476 this is fixed by the webserver serve static function.
+    // SAFARI (IOS) there is a 128KB limit to the size of the HTML. The HTML can reference external resources/images that bring the total over 128KB
+    // SAFARI (IOS) popup browser has some severe limitations (javascript disabled, cookies disabled)
+
+    // Required
+    server.on("/connecttest.txt", [](AsyncWebServerRequest *request)
+              { request->redirect("http://logout.net"); }); // windows 11 captive portal workaround
+    server.on("/wpad.dat", [](AsyncWebServerRequest *request)
+              { request->send(404); }); // Honestly don't understand what this is but a 404 stops win 10 keep calling this repeatedly and panicking the esp32 :)
+
+    // Background responses: Probably not all are Required, but some are. Others might speed things up?
+    // A Tier (commonly used by modern systems)
+    server.on("/generate_204", [](AsyncWebServerRequest *request)
+              { request->redirect(LocalIPURL); }); // android captive portal redirect
+    server.on("/redirect", [](AsyncWebServerRequest *request)
+              { request->redirect(LocalIPURL); }); // microsoft redirect
+    server.on("/hotspot-detect.html", [](AsyncWebServerRequest *request)
+              { request->redirect(LocalIPURL); }); // apple call home
+    server.on("/canonical.html", [](AsyncWebServerRequest *request)
+              { request->redirect(LocalIPURL); }); // firefox captive portal call home
+    server.on("/success.txt", [](AsyncWebServerRequest *request)
+              { request->send(200); }); // firefox captive portal call home
+    server.on("/ncsi.txt", [](AsyncWebServerRequest *request)
+              { request->redirect(LocalIPURL); }); // windows call home
+
+    // return 404 to webpage icon
+    server.on("/favicon.ico", [](AsyncWebServerRequest *request)
+              { request->send(404); }); // webpage icon
+
+    // Serve index.html
+    server.on("/", HTTP_ANY, [&](AsyncWebServerRequest *request)
+              {
+		AsyncWebServerResponse *response = request->beginResponse(200, "text/html", INDEX_HTML, INDEX_HTML_LEN);
+		response->addHeader("Content-Encoding", "gzip");
+    	request->send(response); });
+
+    // Servce logo.svg
+    server.on("/logo.svg", HTTP_ANY, [&](AsyncWebServerRequest *request)
+              {
+		AsyncWebServerResponse *response = request->beginResponse(200, "text/html", LOGO_SVG, LOGO_SVG_LEN);
+		response->addHeader("Content-Encoding", "gzip");
+		response->addHeader("Content-Type", "image/svg+xml");
+    	request->send(response); });
+
+    server.on("/soft-reset", HTTP_ANY, [callbacks](AsyncWebServerRequest *request)
+              {
+		callbacks.resetSettings();
+		request->send(200); });
+
+    auto scanGET = server.on("/scan", HTTP_GET, [callbacks](AsyncWebServerRequest *request)
+                             {
+		String json = "[";
+		int n = WiFi.scanComplete();
+		if (n == WIFI_SCAN_FAILED) {
+			WiFi.scanNetworks(true);
+			return request->send(202);
+		} else if(n == WIFI_SCAN_RUNNING){
+			return request->send(202);
+		} else {
+			// Data structure to store the highest RSSI for each SSID
+            // Warning: DO NOT USE true on this function in an async context!
+            std::vector<Network> combinedNetworks = callbacks.getAnnotatedNetworks(false);
+
+            // Generate JSON response
+            size_t size = 0;
+            for (const auto &network : combinedNetworks)
+            {
+                String ssid = network.ssid;
+				String rssi = String(network.rssi);
+
+				// Escape invalid characters
+				ssid.replace("\\","\\\\");
+				ssid.replace("\"","\\\"");
+				json+= "{";
+				json+= "\"name\":\""+ssid+"\",";
+				json+= "\"rssi\":\""+rssi+"\",";
+				json+= "\"open\":"+String(network.open == WIFI_AUTH_OPEN ? "true,": "false,");
+                json+= "\"saved\":"+String(network.saved ? "true": "false");
+				json+= "}";
+
+				size += 1;
+
+				if (size != combinedNetworks.size())
+				{
+					json+= ",";
+				}
+            }
+
+            WiFi.scanDelete();
+			Serial.println(json);
+
+			if (WiFi.scanComplete() == -2){
+				WiFi.scanNetworks(true);
+			}
+		}
+		json += "]";
+		request->send(200, "application/json", json);
+		json = String(); });
+
+    AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler("/connect", [callbacks](AsyncWebServerRequest *request, JsonVariant &json)
+                                                                           {
+		JsonObject data = json.as<JsonObject>();
+		String ssid = data["ssid"];
+		String pswd = data["pswd"];
+        String api_server = data["server"];
+        callbacks.setConnectionCredentials(ssid, pswd, api_server);
+        String mac = WiFi.macAddress();
+        String message = "{\"ssid\":\"" + ssid + "\",\"mac\":\"" + mac + "\"}";
+        request->send(200, "application/json", message); });
+
+    server.addHandler(handler);
+
+    server.onNotFound([](AsyncWebServerRequest *request)
+                      { request->redirect(LocalIPURL); });
+}

--- a/lib/wificaptive/src/WebServer.h
+++ b/lib/wificaptive/src/WebServer.h
@@ -12,7 +12,7 @@
 struct WifiOperationCallbacks
 {
     std::function<void()> resetSettings;
-    std::function<void(const String, const String, const String)> setConnectionCredentials;
+    std::function<void(const WifiCredentials, const String)> setConnectionCredentials;
     std::function<std::vector<Network>(bool)> getAnnotatedNetworks;
 };
 

--- a/lib/wificaptive/src/WebServer.h
+++ b/lib/wificaptive/src/WebServer.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <ESPAsyncWebServer.h>
+#include <functional>
+#include <vector>
+#include <AsyncJson.h>
+#include "WifiCaptivePage.h"
+#include "wifi-types.h"
+
+#define LocalIPURL "http://4.3.2.1"
+
+/** These are the things that the captive portal web app needs to interact with */
+struct WifiOperationCallbacks
+{
+    std::function<void()> resetSettings;
+    std::function<void(const String, const String, const String)> setConnectionCredentials;
+    std::function<std::vector<Network>(bool)> getAnnotatedNetworks;
+};
+
+void setUpWebserver(AsyncWebServer &server, const IPAddress &localIP, WifiOperationCallbacks callbacks);

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -421,7 +421,7 @@ void WifiCaptive::saveApiServer(String url)
     preferences.end();
 }
 
-std::vector<WifiCaptive::Network> WifiCaptive::getScannedUniqueNetworks(bool runScan)
+std::vector<Network> WifiCaptive::getScannedUniqueNetworks(bool runScan)
 {
     std::vector<Network> uniqueNetworks;
     int n = WiFi.scanComplete();
@@ -500,9 +500,9 @@ std::vector<WifiCaptive::Network> WifiCaptive::getScannedUniqueNetworks(bool run
     return uniqueNetworks;
 }
 
-std::vector<WifiCaptive::WifiCredentials> WifiCaptive::matchNetworks(
-    std::vector<WifiCaptive::Network> &scanResults,
-    WifiCaptive::WifiCredentials savedWifis[])
+std::vector<WifiCredentials> WifiCaptive::matchNetworks(
+    std::vector<Network> &scanResults,
+    WifiCredentials savedWifis[])
 {
     // sort scan results by RSSI
     std::sort(scanResults.begin(), scanResults.end(), [](const Network &a, const Network &b)
@@ -523,9 +523,9 @@ std::vector<WifiCaptive::WifiCredentials> WifiCaptive::matchNetworks(
     return sortedWifis;
 }
 
-std::vector<WifiCaptive::Network> WifiCaptive::combineNetworks(
-    std::vector<WifiCaptive::Network> &scanResults,
-    WifiCaptive::WifiCredentials savedWifis[])
+std::vector<Network> WifiCaptive::combineNetworks(
+    std::vector<Network> &scanResults,
+    WifiCredentials savedWifis[])
 {
     std::vector<Network> combinedNetworks;
     for (auto &network : scanResults)
@@ -605,7 +605,7 @@ bool WifiCaptive::autoConnect()
 
     Log_info("Last used network unavailable, scanning for known networks...");
     std::vector<Network> scanResults = getScannedUniqueNetworks(true);
-    std::vector<WifiCaptive::WifiCredentials> sortedNetworks = matchNetworks(scanResults, _savedWifis);
+    std::vector<WifiCredentials> sortedNetworks = matchNetworks(scanResults, _savedWifis);
     // if no networks found, try to connect to saved wifis
     if (sortedNetworks.size() == 0)
     {

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -1,136 +1,11 @@
 #include "WifiCaptive.h"
 #include <trmnl_log.h>
+#include "WebServer.h"
 
 void WifiCaptive::setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP)
 {
     dnsServer.setTTL(3600);
     dnsServer.start(53, "*", localIP);
-}
-
-void WifiCaptive::setUpWebserver(AsyncWebServer &server, const IPAddress &localIP)
-{
-    //======================== Webserver ========================
-    // WARNING IOS (and maybe macos) WILL NOT POP UP IF IT CONTAINS THE WORD "Success" https://www.esp8266.com/viewtopic.php?f=34&t=4398
-    // SAFARI (IOS) IS STUPID, G-ZIPPED FILES CAN'T END IN .GZ https://github.com/homieiot/homie-esp8266/issues/476 this is fixed by the webserver serve static function.
-    // SAFARI (IOS) there is a 128KB limit to the size of the HTML. The HTML can reference external resources/images that bring the total over 128KB
-    // SAFARI (IOS) popup browser has some severe limitations (javascript disabled, cookies disabled)
-
-    // Required
-    server.on("/connecttest.txt", [](AsyncWebServerRequest *request)
-              { request->redirect("http://logout.net"); }); // windows 11 captive portal workaround
-    server.on("/wpad.dat", [](AsyncWebServerRequest *request)
-              { request->send(404); }); // Honestly don't understand what this is but a 404 stops win 10 keep calling this repeatedly and panicking the esp32 :)
-
-    // Background responses: Probably not all are Required, but some are. Others might speed things up?
-    // A Tier (commonly used by modern systems)
-    server.on("/generate_204", [](AsyncWebServerRequest *request)
-              { request->redirect(LocalIPURL); }); // android captive portal redirect
-    server.on("/redirect", [](AsyncWebServerRequest *request)
-              { request->redirect(LocalIPURL); }); // microsoft redirect
-    server.on("/hotspot-detect.html", [](AsyncWebServerRequest *request)
-              { request->redirect(LocalIPURL); }); // apple call home
-    server.on("/canonical.html", [](AsyncWebServerRequest *request)
-              { request->redirect(LocalIPURL); }); // firefox captive portal call home
-    server.on("/success.txt", [](AsyncWebServerRequest *request)
-              { request->send(200); }); // firefox captive portal call home
-    server.on("/ncsi.txt", [](AsyncWebServerRequest *request)
-              { request->redirect(LocalIPURL); }); // windows call home
-
-    // return 404 to webpage icon
-    server.on("/favicon.ico", [](AsyncWebServerRequest *request)
-              { request->send(404); }); // webpage icon
-
-    // Serve index.html
-    server.on("/", HTTP_ANY, [&](AsyncWebServerRequest *request)
-              {
-		AsyncWebServerResponse *response = request->beginResponse(200, "text/html", INDEX_HTML, INDEX_HTML_LEN);
-		response->addHeader("Content-Encoding", "gzip");
-    	request->send(response); });
-
-    // Servce logo.svg
-    server.on("/logo.svg", HTTP_ANY, [&](AsyncWebServerRequest *request)
-              {
-		AsyncWebServerResponse *response = request->beginResponse(200, "text/html", LOGO_SVG, LOGO_SVG_LEN);
-		response->addHeader("Content-Encoding", "gzip");
-		response->addHeader("Content-Type", "image/svg+xml");
-    	request->send(response); });
-
-    server.on("/soft-reset", HTTP_ANY, [&](AsyncWebServerRequest *request)
-              {
-		resetSettings();
-		if (_resetcallback != NULL) {
-			_resetcallback(); // @CALLBACK
-		}
-		request->send(200); });
-
-    auto scanGET = server.on("/scan", HTTP_GET, [&](AsyncWebServerRequest *request)
-                             {
-		String json = "[";
-		int n = WiFi.scanComplete();
-		if (n == WIFI_SCAN_FAILED) {
-			WiFi.scanNetworks(true);
-			return request->send(202);
-		} else if(n == WIFI_SCAN_RUNNING){
-			return request->send(202);
-		} else {
-			// Data structure to store the highest RSSI for each SSID
-            // Warning: DO NOT USE true on this function in an async context!
-			std::vector<Network> uniqueNetworks = getScannedUniqueNetworks(false);
-            std::vector<Network> combinedNetworks = combineNetworks(uniqueNetworks, _savedWifis);
-
-			// Generate JSON response
-			size_t size = 0;
-			for (const auto& network : combinedNetworks)
-			{
-				String ssid = network.ssid;
-				String rssi = String(network.rssi);
-
-				// Escape invalid characters
-				ssid.replace("\\","\\\\");
-				ssid.replace("\"","\\\"");
-				json+= "{";
-				json+= "\"name\":\""+ssid+"\",";
-				json+= "\"rssi\":\""+rssi+"\",";
-				json+= "\"open\":"+String(network.open == WIFI_AUTH_OPEN ? "true,": "false,");
-                json+= "\"saved\":"+String(network.saved ? "true": "false");
-				json+= "}";
-
-				size += 1;
-
-				if (size != combinedNetworks.size())
-				{
-					json+= ",";
-				}
-			}
-
-            WiFi.scanDelete();
-			Serial.println(json);
-
-			if (WiFi.scanComplete() == -2){
-				WiFi.scanNetworks(true);
-			}
-		}
-		json += "]";
-		request->send(200, "application/json", json);
-		json = String(); });
-
-    AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler("/connect", [&](AsyncWebServerRequest *request, JsonVariant &json)
-                                                                           {
-		JsonObject data = json.as<JsonObject>();
-		String ssid = data["ssid"];
-		String pswd = data["pswd"];
-        String api_server = data["server"];
-		_ssid = ssid;
-		_password = pswd;
-        _api_server = api_server;
-		String mac = WiFi.macAddress();
-		String message =  "{\"ssid\":\"" + _ssid +"\",\"mac\":\"" + mac +"\"}";
-		request->send(200, "application/json", message); });
-
-    server.addHandler(handler);
-
-    server.onNotFound([](AsyncWebServerRequest *request)
-                      { request->redirect(LocalIPURL); });
 }
 
 bool WifiCaptive::startPortal()
@@ -168,7 +43,28 @@ bool WifiCaptive::startPortal()
 
     // configure DSN and WEB server
     setUpDNSServer(*_dnsServer, localIP);
-    setUpWebserver(*_server, localIP);
+
+    WifiOperationCallbacks callbacks = {
+        .resetSettings = [this]()
+        {
+            resetSettings();
+            if (_resetcallback != NULL)
+            {
+                _resetcallback(); // @CALLBACK
+            } },
+        .setConnectionCredentials = [this](const String ssid, const String password, const String api_server)
+        {
+            _ssid = ssid;
+            _password = password;
+            _api_server = api_server; },
+        .getAnnotatedNetworks = [this](bool runScan)
+        {
+            // Warning: DO NOT USE true on this function in an async context!
+            std::vector<Network> uniqueNetworks = getScannedUniqueNetworks(false);
+            std::vector<Network> combinedNetworks = combineNetworks(uniqueNetworks, _savedWifis);
+            return combinedNetworks; }};
+
+    setUpWebserver(*_server, localIP, callbacks);
 
     // begin serving
     _server->begin();

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -46,11 +46,11 @@ private:
     WifiCredentials _savedWifis[WIFI_MAX_SAVED_CREDS];
 
     void setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP);
-    uint8_t connect(String ssid, String pass);
+    uint8_t connect(const WifiCredentials credentials);
     uint8_t waitForConnectResult(uint32_t timeout);
     uint8_t waitForConnectResult();
     void readWifiCredentials();
-    void saveWifiCredentials(String ssid, String pass);
+    void saveWifiCredentials(const WifiCredentials credentials);
     void saveLastUsedWifiIndex(int index);
     int readLastUsedWifiIndex();
     void saveApiServer(String url);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -57,6 +57,7 @@ private:
     std::vector<WifiCredentials> matchNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
     std::vector<Network> getScannedUniqueNetworks(bool runScan);
     std::vector<Network> combineNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
+    bool tryConnectWithRetries(const WifiCredentials creds, int last_used_index);
 
 public:
     /// @brief Starts WiFi configuration portal.

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -9,6 +9,7 @@
 #include "Preferences.h"
 #include "WifiCaptivePage.h"
 #include <ArduinoJson.h>
+#include "wifi-types.h"
 
 #define WIFI_SSID "TRMNL"
 #define WIFI_PASSWORD NULL
@@ -36,19 +37,6 @@
 class WifiCaptive
 {
 private:
-    struct WifiCredentials
-    {
-        String ssid;
-        String pswd;
-    };
-    struct Network
-    {
-        String ssid;
-        int32_t rssi;
-        bool open;
-        bool saved;
-    };
-
     DNSServer *_dnsServer;
     AsyncWebServer *_server;
     String _ssid = "";
@@ -69,9 +57,9 @@ private:
     void saveLastUsedWifiIndex(int index);
     int readLastUsedWifiIndex();
     void saveApiServer(String url);
-    std::vector<WifiCredentials> matchNetworks(std::vector<Network> &scanResults, WifiCaptive::WifiCredentials wifiCredentials[]);
+    std::vector<WifiCredentials> matchNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
     std::vector<Network> getScannedUniqueNetworks(bool runScan);
-    std::vector<Network> combineNetworks(std::vector<Network> &scanResults, WifiCaptive::WifiCredentials wifiCredentials[]);
+    std::vector<Network> combineNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
 
 public:
     /// @brief Starts WiFi configuration portal.

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -26,8 +26,6 @@
 #define WIFI_CONNECTION_ATTEMPTS 3
 // Define max connection timeout
 #define CONNECTION_TIMEOUT 15000
-// Local IP URL
-#define LocalIPURL "http://4.3.2.1"
 
 #define WIFI_SSID_KEY(i) ("wifi_" + String(i) + "_ssid").c_str()
 #define WIFI_PSWD_KEY(i) ("wifi_" + String(i) + "_pswd").c_str()
@@ -48,7 +46,6 @@ private:
     WifiCredentials _savedWifis[WIFI_MAX_SAVED_CREDS];
 
     void setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP);
-    void setUpWebserver(AsyncWebServer &server, const IPAddress &localIP);
     uint8_t connect(String ssid, String pass);
     uint8_t waitForConnectResult(uint32_t timeout);
     uint8_t waitForConnectResult();

--- a/lib/wificaptive/src/wifi-types.h
+++ b/lib/wificaptive/src/wifi-types.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Arduino.h>
+
+struct WifiCredentials
+{
+    String ssid;
+    String pswd;
+};
+
+struct Network
+{
+    String ssid;
+    int32_t rssi;
+    bool open;
+    bool saved;
+};


### PR DESCRIPTION
Some small steps toward better organization of `lib/wificaptive`:
- pull `setUpWebserver()` into a separate function to decouple it from `WifiCaptive`
- use `WifiCredentials` struct more broadly instead of passing around ssid / password Strings
- add new `tryConnectWithRetries()` helper based on repeated pattern

I intend to do more here, but this is a good stopping point for a PR. I tested it on-device and the captive portal is working fine.