### PR TITLE
begin OG+ support

### DIFF
--- a/lib/trmnl/src/png.cpp
+++ b/lib/trmnl/src/png.cpp
@@ -15,7 +15,7 @@ image_err_e processPNG(PNG *png, uint8_t *&decoded_buffer)
   uint32_t height = png->getHeight();
   uint32_t bpp = png->getBpp();
 
-  if (width != 800 || height != 480 || bpp != 1)
+  if (width != 800 || height != 480)
   {
     Log_error("PNG_BAD_SIZE");
     return PNG_BAD_SIZE;


### PR DESCRIPTION
announced today that soon we'll offer an upgraded EPD (+ PCB) for the OG device model.

the new EPD can render images like this:

![og_plus_example](https://github.com/user-attachments/assets/3f512fbb-bb43-4b29-86bd-6d05efa591aa)

to get started i disabled [getBpp()](https://github.com/bitbank2/PNGdec/blob/bd691f9050024f678f4331c35b6f92c5d3cdf600/src/PNGdec.cpp#L135) check. not sure this is super useful anyway. if we keep it i suggest a unique error vs combining with width/height checks. 

serial monitor where it blows up:

```
I: src/bl.cpp [2007]: file /current.png writing success - 15263 bytes
I: src/bl.cpp [753]: Decoding png
Attempting to open /current.png from SPIFFS
E: lib/trmnl/src/png.cpp [26]: PNG_SUCCESS
```

preview of unhandled error:

```
Guru Meditation Error: Core  0 panic'ed (Store access fault). Exception was unhandled.

Core  0 register dump:
MEPC    : 0x4038c4c6  RA      : 0x4038c452  SP      : 0x3fc9f8f0  GP      : 0x3fc8f000  
  #0  0x4038c4c6 in remove_free_block at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf.c:207
      (inlined by) block_locate_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf.c:442
      (inlined by) tlsf_malloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf.c:850

TP      : 0x3fc5ffac  T0      : 0x420655d2  T1      : 0x0000000f  T2      : 0x00008002  
S0/FP   : 0x3fcd2668  S1      : 0x0000100c  A0      : 0x00000008  A1      : 0x0000100c  
A2      : 0x00000000  A3      : 0x00000004  A4      : 0xfe5fffff  A5      : 0xe3ffff6f  
A6      : 0xffffffff  A7      : 0x0000000a  S2      : 0x00000009  S3      : 0xc05813ed  
S4      : 0x3fc991e8  S5      : 0x3fc991c4  S6      : 0x3fc9921c  S7      : 0xc0380000  
S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00060000  S11     : 0x3fc98000  
T3      : 0x0000676e  T4      : 0x702e7473  T5      : 0x616c2f01  T6      : 0x00000ab3  
MSTATUS : 0x00001881  MTVEC   : 0x40380001  MCAUSE  : 0x00000007  MTVAL   : 0xfe60000b  
MHARTID : 0x00000000  

Stack memory:
3fc9f8f0: 0x00000067 0x00000000 0x00000000 0xc0380000 0x00000000 0x3fc99000 0xc0380000 0x00001004
```

given this is the same EPD as the `seeed_xiao_esp32s3` board, i attempted bumping PNGDec lib to `https://github.com/bitbank2/PNGdec.git#53eea10f6a04bceadec3f57b1c3a9cd5c3cb40d7`, same as the s3 env. next i attempted latest main.

perhaps we can also DRY up Waveshare drivers (`EPD_7IN5_V2` prefix) and use var instead.