### PR TITLE
version suffix for local/CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Build release firmware
+        env:
+          INCLUDE_GIT_HASH_IN_VERSION_NUMBER: true
         run: pio run -e trmnl
 
       - name: Name files

--- a/include/config.h
+++ b/include/config.h
@@ -5,10 +5,6 @@
 #define FW_MINOR_VERSION 5
 #define FW_PATCH_VERSION 9
 
-#ifndef FW_VERSION_SUFFIX
-#define FW_VERSION_SUFFIX ""
-#endif
-
 #define LOG_MAX_NOTES_NUMBER 5
 
 #define PREFERENCES_API_KEY "api_key"

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,10 @@
 #define FW_MINOR_VERSION 5
 #define FW_PATCH_VERSION 9
 
+#ifndef FW_VERSION_SUFFIX
+#define FW_VERSION_SUFFIX ""
+#endif
+
 #define LOG_MAX_NOTES_NUMBER 5
 
 #define PREFERENCES_API_KEY "api_key"

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,6 +60,8 @@ build_flags =
 
 [env:trmnl]
 extends = env:esp32-c3-devkitc-02
+extra_scripts = scripts/git_version.py
+include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_TRMNL
@@ -68,6 +70,7 @@ build_flags =
 extends = env:esp32_base
 board = esp32-c3-devkitc-02 # Specify board for local env (assuming C3 for local debugging)
 extra_scripts = scripts/git_version.py
+include_git_hash = true
 build_flags =
 	-D BOARD_TRMNL
 	-D ARDUINO_USB_MODE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -74,6 +74,7 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=0
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+	-D FW_VERSION_SUFFIX=\"-local\"
 # lib_deps are inherited from esp32_base
 # monitor_filters are inherited from esp32_base
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,7 @@ build_flags =
 [env:local]
 extends = env:esp32_base
 board = esp32-c3-devkitc-02 # Specify board for local env (assuming C3 for local debugging)
+extra_scripts = scripts/git_version.py
 build_flags =
 	-D BOARD_TRMNL
 	-D ARDUINO_USB_MODE=1
@@ -74,7 +75,6 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=0
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
-	-D FW_VERSION_SUFFIX=\"-local\"
 # lib_deps are inherited from esp32_base
 # monitor_filters are inherited from esp32_base
 

--- a/scripts/git_version.py
+++ b/scripts/git_version.py
@@ -1,0 +1,13 @@
+Import("env", "projenv")
+import subprocess
+
+try:
+    git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+
+    print("Using git hash", git_hash)
+    
+    projenv.Append(CPPDEFINES=[("GIT_COMMIT_HASH", f'\\"+{git_hash}\\"')])
+            
+except:
+    print("No git repository found, using default empty GIT_COMMIT_HASH")
+    pass

--- a/scripts/git_version.py
+++ b/scripts/git_version.py
@@ -2,12 +2,15 @@ Import("env", "projenv")
 import subprocess
 
 try:
-    git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
-
-    print("Using git hash", git_hash)
+    include_hash = env.GetProjectOption("include_git_hash", "false").lower() == "true"
     
-    projenv.Append(CPPDEFINES=[("GIT_COMMIT_HASH", f'\\"+{git_hash}\\"')])
+    if include_hash:
+        git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+        print(f"Using git hash: {git_hash}")
+        projenv.Append(CPPDEFINES=[("FW_VERSION_SUFFIX", f'\\"+{git_hash}\\"')])
+    else:
+        print("Skipping git hash (include_git_hash = false)")
             
 except:
-    print("No git repository found, using default empty GIT_COMMIT_HASH")
+    print("No git repository found, using default empty FW_VERSION_SUFFIX")
     pass

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -83,7 +83,11 @@ static DeviceStatusStamp getDeviceStatusStamp();
 void submitLog(const char *format, time_t time, int line, const char *file, ...);
 void log_nvs_usage();
 
-String fw_version_string = String(FW_MAJOR_VERSION) + "." + String(FW_MINOR_VERSION) + "." + String(FW_PATCH_VERSION) + String(FW_VERSION_SUFFIX);
+#ifndef GIT_COMMIT_HASH
+#define GIT_COMMIT_HASH ""
+#endif
+
+String fw_version_string = String(FW_MAJOR_VERSION) + "." + String(FW_MINOR_VERSION) + "." + String(FW_PATCH_VERSION) + String(GIT_COMMIT_HASH);
 
 #define submit_log(format, ...) submitLog(format, getTime(), __LINE__, __FILE__, ##__VA_ARGS__);
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -83,11 +83,11 @@ static DeviceStatusStamp getDeviceStatusStamp();
 void submitLog(const char *format, time_t time, int line, const char *file, ...);
 void log_nvs_usage();
 
-#ifndef GIT_COMMIT_HASH
-#define GIT_COMMIT_HASH ""
+#ifndef FW_VERSION_SUFFIX
+#define FW_VERSION_SUFFIX ""
 #endif
 
-String fw_version_string = String(FW_MAJOR_VERSION) + "." + String(FW_MINOR_VERSION) + "." + String(FW_PATCH_VERSION) + String(GIT_COMMIT_HASH);
+String fw_version_string = String(FW_MAJOR_VERSION) + "." + String(FW_MINOR_VERSION) + "." + String(FW_PATCH_VERSION) + String(FW_VERSION_SUFFIX);
 
 #define submit_log(format, ...) submitLog(format, getTime(), __LINE__, __FILE__, ##__VA_ARGS__);
 
@@ -298,7 +298,7 @@ void bl_init(void)
 
     Log_info("FW version %s", fw_version_string);
 
-    showMessageWithLogo(WIFI_CONNECT, "", false, "%s", fw_version_string);
+    showMessageWithLogo(WIFI_CONNECT, "", false, fw_version_string.c_str(), "");
     WifiCaptivePortal.setResetSettingsCallback(resetDeviceCredentials);
     res = WifiCaptivePortal.startPortal();
     if (!res)


### PR DESCRIPTION
It's hard to keep track of whether my devices are on release builds or custom builds. This small change adds a suffix to tell them apart:

<img width="255" alt="image" src="https://github.com/user-attachments/assets/0492833e-3bfe-4cf6-9c67-a0014b11e0e6" />
