### PR TITLE
publish-build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - uses: maxim-lobanov/setup-xcode@v1
         if: matrix.os == 'macos-15'
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  build-test:
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -55,3 +55,39 @@ jobs:
 
       - name: static analysis
         run: pio check --skip-packages --fail-on-defect high
+
+  publish-build:
+    needs: build-test
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build release firmware
+        run: pio run -e trmnl
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trmnl-firmware-${{ github.sha }}
+          path: |
+            .pio/build/trmnl/firmware.bin
+            .pio/build/trmnl/firmware.elf
+            .pio/build/trmnl/firmware.map
+          retention-days: 30


### PR DESCRIPTION
Here's a new CI job which will produce (and upload!) a firmware image on every `main` commit. You can go in the job history and download it.

Eventually this could be hooked in to the [release](https://github.com/usetrmnl/trmnl-firmware/releases) process so that it doesn't depend on manually performing builds on anyone's workstation.