### PR TITLE
Avoid pio warning

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,7 +3,7 @@
 
 #define FW_MAJOR_VERSION 1
 #define FW_MINOR_VERSION 5
-#define FW_PATCH_VERSION 10
+#define FW_PATCH_VERSION 11
 
 #define LOG_MAX_NOTES_NUMBER 5
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -115,14 +115,14 @@ build_flags =
 [env:trmnl]
 extends = env:esp32-c3-devkitc-02
 extra_scripts = scripts/git_version.py
-include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
+custom_include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_TRMNL
 
 [env:local]
 extends = env:trmnl
-include_git_hash = true
+custom_include_git_hash = true
 build_flags =
 	${env:trmnl.build_flags}
 	-D ARDUINO_USB_MODE=1

--- a/scripts/git_version.py
+++ b/scripts/git_version.py
@@ -2,14 +2,14 @@ Import("env", "projenv")
 import subprocess
 
 try:
-    include_hash = env.GetProjectOption("include_git_hash", "false").lower() == "true"
+    include_hash = env.GetProjectOption("custom_include_git_hash", "false").lower() == "true"
     
     if include_hash:
         git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
         print(f"Using git hash: {git_hash}")
         projenv.Append(CPPDEFINES=[("FW_VERSION_SUFFIX", f'\\"+{git_hash}\\"')])
     else:
-        print("Skipping git hash (include_git_hash = false)")
+        print("Skipping git hash (custom_include_git_hash = false)")
             
 except:
     print("No git repository found, using default empty FW_VERSION_SUFFIX")


### PR DESCRIPTION
rename a config to avoid this warning:
```
Warning! Ignore unknown configuration option `include_git_hash` in section [env:trmnl]
```