### PR TITLE
Fove firmware version string into compile-time constant

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,17 @@
 #define FW_MINOR_VERSION 5
 #define FW_PATCH_VERSION 11
 
+// Helper macros for stringification
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#ifndef FW_VERSION_SUFFIX
+#define FW_VERSION_SUFFIX ""
+#endif
+
+// Compile-time firmware version string
+#define FW_VERSION_STRING TOSTRING(FW_MAJOR_VERSION) "." TOSTRING(FW_MINOR_VERSION) "." TOSTRING(FW_PATCH_VERSION) FW_VERSION_SUFFIX
+
 #define LOG_MAX_NOTES_NUMBER 5
 
 #define PREFERENCES_API_KEY "api_key"

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -83,12 +83,6 @@ static DeviceStatusStamp getDeviceStatusStamp();
 void submitLog(const char *format, time_t time, int line, const char *file, ...);
 void log_nvs_usage();
 
-#ifndef FW_VERSION_SUFFIX
-#define FW_VERSION_SUFFIX ""
-#endif
-
-String fw_version_string = String(FW_MAJOR_VERSION) + "." + String(FW_MINOR_VERSION) + "." + String(FW_PATCH_VERSION) + String(FW_VERSION_SUFFIX);
-
 #define submit_log(format, ...) submitLog(format, getTime(), __LINE__, __FILE__, ##__VA_ARGS__);
 
 void wait_for_serial()
@@ -253,7 +247,7 @@ void bl_init(void)
   // Mount SPIFFS
   filesystem_init();
 
-  Log_info("Firmware version %s", fw_version_string);
+  Log_info("Firmware version %s", FW_VERSION_STRING);
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);
   Log_info("ESP-IDF version %d.%d.%d", ESP_IDF_VERSION_MAJOR, ESP_IDF_VERSION_MINOR, ESP_IDF_VERSION_PATCH);
   list_files();
@@ -296,9 +290,9 @@ void bl_init(void)
     // WiFi credentials are not saved - start captive portal
     Log.info("%s [%d]: WiFi NOT saved\r\n", __FILE__, __LINE__);
 
-    Log_info("FW version %s", fw_version_string);
+    Log_info("FW version %s", FW_VERSION_STRING);
 
-    showMessageWithLogo(WIFI_CONNECT, "", false, fw_version_string.c_str(), "");
+    showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, "");
     WifiCaptivePortal.setResetSettingsCallback(resetDeviceCredentials);
     res = WifiCaptivePortal.startPortal();
     if (!res)
@@ -551,7 +545,7 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
 
   inputs.batteryVoltage = readBatteryVoltage();
 
-  inputs.firmwareVersion = String(fw_version_string);
+  inputs.firmwareVersion = String(FW_VERSION_STRING);
 
   inputs.rssi = WiFi.RSSI();
   inputs.displayWidth = display_width();
@@ -1517,7 +1511,7 @@ static void getDeviceCredentials()
 
         https.addHeader("ID", WiFi.macAddress());
         https.addHeader("Content-Type", "application/json");
-        https.addHeader("FW-Version", fw_version_string);
+        https.addHeader("FW-Version", FW_VERSION_STRING);
         Log.info("%s [%d]: Device MAC address: %s\r\n", __FILE__, __LINE__, WiFi.macAddress().c_str());
 
         int httpCode = https.GET();
@@ -2165,7 +2159,7 @@ DeviceStatusStamp getDeviceStatusStamp()
   parseWifiStatusToStr(deviceStatus.wifi_status, sizeof(deviceStatus.wifi_status), WiFi.status());
   deviceStatus.refresh_rate = preferences.getUInt(PREFERENCES_SLEEP_TIME_KEY);
   deviceStatus.time_since_last_sleep = time_since_sleep;
-  snprintf(deviceStatus.current_fw_version, sizeof(deviceStatus.current_fw_version), "%s", fw_version_string);
+  snprintf(deviceStatus.current_fw_version, sizeof(deviceStatus.current_fw_version), "%s", FW_VERSION_STRING);
   parseSpecialFunctionToStr(deviceStatus.special_function, sizeof(deviceStatus.special_function), special_function);
   deviceStatus.battery_voltage = readBatteryVoltage();
   parseWakeupReasonToStr(deviceStatus.wakeup_reason, sizeof(deviceStatus.wakeup_reason), esp_sleep_get_wakeup_cause());


### PR DESCRIPTION
This will make it less error-prone to work with (never have to `.c_str()` it)