### PR TITLE
Log more WiFi connection error detail

### DIFF
--- a/lib/trmnl/include/logging_parcers.h
+++ b/lib/trmnl/include/logging_parcers.h
@@ -2,6 +2,5 @@
 
 #include "esp_sleep.h"
 
-bool parseWifiStatusToStr(char *buffer, size_t buffer_size, wl_status_t wifi_status);
 bool parseWakeupReasonToStr(char *buffer, size_t buffer_size, esp_sleep_source_t wakeup_reason);
 

--- a/lib/trmnl/src/logging_parsers.cpp
+++ b/lib/trmnl/src/logging_parsers.cpp
@@ -1,17 +1,6 @@
 #include <string.h>
 
 typedef enum {
-    WL_NO_SHIELD        = 255,   // for compatibility with WiFi Shield library
-    WL_IDLE_STATUS      = 0,
-    WL_NO_SSID_AVAIL    = 1,
-    WL_SCAN_COMPLETED   = 2,
-    WL_CONNECTED        = 3,
-    WL_CONNECT_FAILED   = 4,
-    WL_CONNECTION_LOST  = 5,
-    WL_DISCONNECTED     = 6
-} wl_status_t;
-
-typedef enum {
     ESP_SLEEP_WAKEUP_UNDEFINED,    //!< In case of deep sleep, reset was not caused by exit from deep sleep
     ESP_SLEEP_WAKEUP_ALL,          //!< Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
     ESP_SLEEP_WAKEUP_EXT0,         //!< Wakeup caused by external signal using RTC_IO
@@ -27,28 +16,10 @@ typedef enum {
     ESP_SLEEP_WAKEUP_BT,           //!< Wakeup caused by BT (light sleep only)
 } esp_sleep_source_t;
 
-
-struct WifiStatusNode
-{
-  const char *name;
-  wl_status_t value;
-};
-
 struct WakeupReasonNode
 {
   const char *name;
   esp_sleep_source_t value;
-};
-
-static const WifiStatusNode wifiStatusMap[] = {
-    {"no_shield", WL_NO_SHIELD},
-    {"idle_status", WL_IDLE_STATUS},
-    {"no_ssid_avail", WL_NO_SSID_AVAIL},
-    {"scan_completed", WL_SCAN_COMPLETED},
-    {"connected", WL_CONNECTED},
-    {"connect_failed", WL_CONNECT_FAILED},
-    {"connection_lost", WL_CONNECTION_LOST},
-    {"disconnected", WL_DISCONNECTED},
 };
 
 static const WakeupReasonNode wakeupReasonMap[] = {
@@ -66,19 +37,6 @@ static const WakeupReasonNode wakeupReasonMap[] = {
     {"cocpu_trap_trig", ESP_SLEEP_WAKEUP_COCPU_TRAP_TRIG},
     {"bt", ESP_SLEEP_WAKEUP_BT},
 };
-
-bool parseWifiStatusToStr(char *buffer, size_t buffer_size, wl_status_t wifi_status)
-{
-  for (const WifiStatusNode &entry : wifiStatusMap)
-  {
-    if (wifi_status == entry.value)
-    {
-      strncpy(buffer, entry.name, buffer_size);
-      return true;
-    }
-  }
-  return false;
-}
 
 bool parseWakeupReasonToStr(char *buffer, size_t buffer_size, esp_sleep_source_t wakeup_reason)
 {

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -2,6 +2,10 @@
 #include <WiFi.h>
 #include <trmnl_log.h>
 #include "WebServer.h"
+#include "wifi-helpers.h"
+#include "esp_event.h"
+#include "esp_wifi.h"
+#include "connect.h"
 
 void WifiCaptive::setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP)
 {
@@ -118,8 +122,9 @@ bool WifiCaptive::startPortal()
     {
         Log_info("Not connected after AP disconnect");
         WiFi.mode(WIFI_STA);
-        WiFi.begin(_ssid.c_str(), _password.c_str());
-        waitForConnectResult();
+
+        auto result = initiateConnectionAndWaitForOutcome({_ssid, _password});
+        status = result.status;
     }
 
     // stop dsn
@@ -157,52 +162,19 @@ void WifiCaptive::resetSettings()
     WiFi.eraseAP();
 }
 
-uint8_t WifiCaptive::connect(const WifiCredentials credentials)
+wl_status_t WifiCaptive::connect(const WifiCredentials credentials)
 {
-    uint8_t connRes = (uint8_t)WL_NO_SSID_AVAIL;
+    wl_status_t connRes = WL_NO_SSID_AVAIL;
 
     if (credentials.ssid != "")
     {
         WiFi.enableSTA(true);
-        WiFi.begin(credentials.ssid.c_str(), credentials.pswd.c_str());
-        connRes = waitForConnectResult();
+
+        auto result = initiateConnectionAndWaitForOutcome(credentials);
+        connRes = result.status;
     }
 
     return connRes;
-}
-
-/**
- * waitForConnectResult
- * @param  uint16_t timeout  in seconds
- * @return uint8_t  WL Status
- */
-uint8_t WifiCaptive::waitForConnectResult(uint32_t timeout)
-{
-    if (timeout == 0)
-    {
-        return WiFi.waitForConnectResult();
-    }
-
-    unsigned long timeoutmillis = millis() + timeout;
-    uint8_t status = WiFi.status();
-
-    while (millis() < timeoutmillis)
-    {
-        status = WiFi.status();
-        // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not to timeout if waiting on IP
-        if (status == WL_CONNECTED || status == WL_CONNECT_FAILED)
-        {
-            return status;
-        }
-        delay(100);
-    }
-
-    return status;
-}
-
-uint8_t WifiCaptive::waitForConnectResult()
-{
-    return waitForConnectResult(CONNECTION_TIMEOUT);
 }
 
 void WifiCaptive::setResetSettingsCallback(std::function<void()> func)

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -46,20 +46,19 @@ private:
     WifiCredentials _savedWifis[WIFI_MAX_SAVED_CREDS];
 
     void setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP);
-    uint8_t connect(const WifiCredentials credentials);
-    uint8_t waitForConnectResult(uint32_t timeout);
-    uint8_t waitForConnectResult();
     void readWifiCredentials();
     void saveWifiCredentials(const WifiCredentials credentials);
     void saveLastUsedWifiIndex(int index);
     int readLastUsedWifiIndex();
     void saveApiServer(String url);
+    bool tryConnectWithRetries(const WifiCredentials creds, int last_used_index);
     std::vector<WifiCredentials> matchNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
     std::vector<Network> getScannedUniqueNetworks(bool runScan);
     std::vector<Network> combineNetworks(std::vector<Network> &scanResults, WifiCredentials wifiCredentials[]);
-    bool tryConnectWithRetries(const WifiCredentials creds, int last_used_index);
 
 public:
+    wl_status_t connect(const WifiCredentials credentials);
+
     /// @brief Starts WiFi configuration portal.
     /// @return True if successfully connected to provided SSID, false otherwise.
     bool startPortal();

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -1,0 +1,88 @@
+#include "connect.h"
+#include "WifiCaptive.h"
+#include <trmnl_log.h>
+#include "WebServer.h"
+#include "wifi-helpers.h"
+#include "esp_event.h"
+#include "esp_wifi.h"
+
+void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *eventData)
+{
+    switch (event)
+    {
+    case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+        Log_info("Wifi: Event STA_GOT_IP, IP: %s, Gateway: %s",
+                 (IPAddress(info.got_ip.ip_info.ip.addr)).toString(),
+                 (IPAddress(info.got_ip.ip_info.gw.addr)).toString());
+        break;
+    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+        Log_info("Wifi: Event STA_CONNECTED SSID: %s, BSSID: %s, channel: %d, authmode: %d",
+                 String((char *)info.wifi_sta_connected.ssid).c_str(),
+                 WiFi.BSSIDstr().c_str(),
+                 info.wifi_sta_connected.channel,
+                 info.wifi_sta_connected.authmode);
+        break;
+    case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+        eventData->disconnected = true;
+        eventData->disconnectReason = (wifi_err_reason_t)info.wifi_sta_disconnected.reason;
+        Log_info("Wifi: Event STA_DISCONNECTED, reason: %s", WiFi.disconnectReasonName((wifi_err_reason_t)info.wifi_sta_disconnected.reason));
+        break;
+    default:
+        Log_info("Wifi: Event (other): %s", WiFi.eventName((arduino_event_id_t)event));
+        break;
+    }
+}
+
+WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials)
+{
+    WifiEventData eventData;
+
+    for (int i = ARDUINO_EVENT_WIFI_READY; i < ARDUINO_EVENT_MAX; i++)
+    {
+        WiFi.onEvent([i, &eventData](WiFiEvent_t event, WiFiEventInfo_t info)
+                     {
+                         eventData.eventCount++;
+
+                         captureEventData(event, info, &eventData); },
+                     (arduino_event_id_t)i);
+    }
+
+    auto beginResult = WiFi.begin(credentials.ssid.c_str(), credentials.pswd.c_str());
+    Log_info("WiFi: begin, starting from status %s", wifiStatusStr(beginResult));
+
+    auto result = waitForConnectResult(CONNECTION_TIMEOUT);
+
+    // Clean up Arduino event handlers
+    for (int i = ARDUINO_EVENT_WIFI_READY; i < ARDUINO_EVENT_MAX; i++)
+    {
+        WiFi.removeEvent(i);
+    }
+
+    return {result, eventData};
+}
+
+wl_status_t waitForConnectResult(uint32_t timeout)
+{
+
+    unsigned long timeoutmillis = millis() + timeout;
+    wl_status_t status = WiFi.status();
+
+    while (millis() < timeoutmillis)
+    {
+        wl_status_t newStatus = WiFi.status();
+        if (newStatus != status)
+        {
+            Log_info("WiFi: status changed from %s to %s", wifiStatusStr(status), wifiStatusStr(newStatus));
+        }
+        status = newStatus;
+        // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not to timeout if waiting on IP
+        if (status == WL_CONNECTED || status == WL_CONNECT_FAILED)
+        {
+            return status;
+        }
+        delay(100);
+    }
+
+    Log_info("WiFi: connect timed out after %d ms", timeout);
+    return status;
+}

--- a/lib/wificaptive/src/connect.h
+++ b/lib/wificaptive/src/connect.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <WiFiType.h>
+#include "wifi-types.h"
+
+WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials);
+wl_status_t waitForConnectResult(uint32_t timeout);

--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -20,4 +20,5 @@ const char *wifiStatusStr(wl_status_t wifi_status)
       return entry.name;
     }
   }
+  return nullptr;
 }

--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -1,0 +1,23 @@
+#include "wifi-helpers.h"
+
+static const WifiStatusNode wifiStatusMap[] = {
+    {"no_shield", WL_NO_SHIELD},
+    {"idle_status", WL_IDLE_STATUS},
+    {"no_ssid_avail", WL_NO_SSID_AVAIL},
+    {"scan_completed", WL_SCAN_COMPLETED},
+    {"connected", WL_CONNECTED},
+    {"connect_failed", WL_CONNECT_FAILED},
+    {"connection_lost", WL_CONNECTION_LOST},
+    {"disconnected", WL_DISCONNECTED},
+};
+
+const char *wifiStatusStr(wl_status_t wifi_status)
+{
+  for (const WifiStatusNode &entry : wifiStatusMap)
+  {
+    if (wifi_status == entry.value)
+    {
+      return entry.name;
+    }
+  }
+}

--- a/lib/wificaptive/src/wifi-helpers.h
+++ b/lib/wificaptive/src/wifi-helpers.h
@@ -1,0 +1,10 @@
+#include <WiFiType.h>
+#include <Arduino.h>
+
+struct WifiStatusNode
+{
+  const char *name;
+  wl_status_t value;
+};
+
+const char *wifiStatusStr(wl_status_t wifi_status);

--- a/lib/wificaptive/src/wifi-types.h
+++ b/lib/wificaptive/src/wifi-types.h
@@ -15,3 +15,16 @@ struct Network
     bool open;
     bool saved;
 };
+
+struct WifiEventData
+{
+    bool disconnected = false;
+    wifi_err_reason_t disconnectReason = wifi_err_reason_t::WIFI_REASON_UNSPECIFIED;
+    int eventCount = 0;
+};
+
+struct WifiConnectionResult
+{
+    wl_status_t status;
+    WifiEventData eventData;
+};

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -34,6 +34,7 @@
 #include <serialize_log.h>
 #include <preferences_persistence.h>
 #include "logo_small.h"
+#include <wifi-helpers.h>
 
 bool pref_clear = false;
 String new_filename = "";
@@ -2170,7 +2171,7 @@ DeviceStatusStamp getDeviceStatusStamp()
   DeviceStatusStamp deviceStatus = {};
 
   deviceStatus.wifi_rssi_level = WiFi.RSSI();
-  parseWifiStatusToStr(deviceStatus.wifi_status, sizeof(deviceStatus.wifi_status), WiFi.status());
+  strncpy(deviceStatus.wifi_status, wifiStatusStr(WiFi.status()), sizeof(deviceStatus.wifi_status) - 1);
   deviceStatus.refresh_rate = preferences.getUInt(PREFERENCES_SLEEP_TIME_KEY);
   deviceStatus.time_since_last_sleep = time_since_sleep;
   snprintf(deviceStatus.current_fw_version, sizeof(deviceStatus.current_fw_version), "%s", FW_VERSION_STRING);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -260,6 +260,17 @@ void bl_init(void)
   log_nvs_usage();
 
   WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
+
+// uncomment this to hardcode WiFi credentials (useful for testing wifi errors, etc.)
+// #define HARDCODED_WIFI
+#ifdef HARDCODED_WIFI
+  WifiCredentials hardcodedCreds = {.ssid = "ssid-goes-here", .pswd = "password-goes-here"};
+  Log_info("Hardcoded WiFi: connecting to SSID '%s'", hardcodedCreds.ssid.c_str());
+  auto connectResult = WifiCaptivePortal.connect(hardcodedCreds);
+  Log_info("Hardcoded WiFi: connect result '%s'", wifiStatusStr(connectResult));
+// goToSleep();
+#else
+
   if (WifiCaptivePortal.isSaved())
   {
     // WiFi saved, connection
@@ -317,6 +328,8 @@ void bl_init(void)
     Log.info("%s [%d]: WiFi connected\r\n", __FILE__, __LINE__);
     preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
   }
+
+#endif
 
   // clock synchronization
   if (setClock())


### PR DESCRIPTION
Capture more detail during WiFi connection attempts. For now it's just logged. Here are a few examples:

#### Good network:

```
I: src/bl.cpp [268]: Hardcoded WiFi: connecting to SSID 'test-wpa2'
I: lib/wificaptive/src/connect.cpp [51]: WiFi: begin, starting from status disconnected
I: lib/wificaptive/src/connect.cpp [23]: Wifi: Event STA_CONNECTED SSID: test-wpa2, BSSID: DA:F9:21:84:BC:3F, channel: 6, authmode: 3
I: lib/wificaptive/src/connect.cpp [77]: WiFi: status changed from disconnected to idle_status
I: lib/wificaptive/src/connect.cpp [16]: Wifi: Event STA_GOT_IP, IP: 192.168.0.233, Gateway: 192.168.0.1
I: lib/wificaptive/src/connect.cpp [77]: WiFi: status changed from idle_status to connected
I: src/bl.cpp [270]: Hardcoded WiFi: connect result 'connected'
```

#### Absent network:
```
I: src/bl.cpp [268]: Hardcoded WiFi: connecting to SSID 'does-not-exist'
I: lib/wificaptive/src/connect.cpp [51]: WiFi: begin, starting from status disconnected
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [77]: WiFi: status changed from disconnected to no_ssid_avail
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: NO_AP_FOUND
I: lib/wificaptive/src/connect.cpp [88]: WiFi: connect timed out after 15000 ms
I: src/bl.cpp [270]: Hardcoded WiFi: connect result 'no_ssid_avail'
```

#### Bad password:
```
I: src/bl.cpp [269]: Hardcoded WiFi: connecting to SSID 'test-wpa2'
I: lib/wificaptive/src/connect.cpp [51]: WiFi: begin, starting from status disconnected
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [28]: Wifi: Event STA_DISCONNECTED, reason: 4WAY_HANDSHAKE_TIMEOUT
I: lib/wificaptive/src/connect.cpp [88]: WiFi: connect timed out after 15000 ms
I: src/bl.cpp [271]: Hardcoded WiFi: connect result 'disconnected'
```
(note in particular the disconnect _reason_!)

In the future this could feed more-detailed messages on the captive portal and on device error screens.