### PR TITLE
Disable light sleep in local development

### DIFF
--- a/lib/bb_epaper/src/bb_ep.inl
+++ b/lib/bb_epaper/src/bb_ep.inl
@@ -1673,8 +1673,12 @@ int bbepCreateVirtual(BBEPDISP *pBBEP, int iWidth, int iHeight, int iFlags)
 // Put the ESP32 into light sleep for N milliseconds
 void bbepLightSleep(uint32_t u32Millis)
 {
-  esp_sleep_enable_timer_wakeup(u32Millis * 1000L);
-  esp_light_sleep_start();
+#ifdef DO_NOT_LIGHT_SLEEP
+    delay(u32Millis);
+#else
+    esp_sleep_enable_timer_wakeup(u32Millis * 1000L);
+    esp_light_sleep_start();
+#endif
 }
 
 //

--- a/platformio.ini
+++ b/platformio.ini
@@ -129,6 +129,8 @@ build_flags =
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+	# light sleep interrupts the serial connection and we miss logs
+	-D DO_NOT_LIGHT_SLEEP=1
 
 [env:seeed_xiao_esp32c3]
 extends = deps_app, esp32_base

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -722,6 +722,8 @@ static https_request_err_e downloadAndShow()
             return HTTPS_WRONG_IMAGE_SIZE;
           }
 
+          submitStoredLogs();
+
           WiFi.disconnect(true); // no need for WiFi, save power starting here
           Log.info("%s [%d]: Received successfully; WiFi off\r\n", __FILE__, __LINE__);
           bool bmp_rename = false;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -32,8 +32,12 @@ void display_init(void)
  */
 void display_sleep(uint32_t u32Millis)
 {
-  esp_sleep_enable_timer_wakeup(u32Millis * 1000L);
-  esp_light_sleep_start();
+#ifdef DO_NOT_LIGHT_SLEEP
+    delay(u32Millis);
+#else
+    esp_sleep_enable_timer_wakeup(u32Millis * 1000L);
+    esp_light_sleep_start();
+#endif
 }
 
 /**


### PR DESCRIPTION
The new EPD code uses ESP32 light sleep (cool!). Unfortunately, this kills the serial connection and it doesn't seem to recover, so we lose a bunch of logs. It looks like this:

```
I: src/bl.cpp [238]: Display TRMNL logo start
I: src/display.cpp [242]: Paint_NewImage 0
I: src/display.cpp [243]: show image for array
I: src/display.cpp [279]: Display refresh start
Disconnected (read failed: [Errno 6] Device not configured)
Reconnecting to /dev/cu.usbmodem101 .......
```

This PR adds a condition to fall back to using `delay()` when working in the "local" environment. (e.g. `pio run -e local -t upload && pio device monitor -e local`)

Prod builds (and all other envs) will still get the light sleep.

I also added one more `submitStoredLogs()` call right before the new early WiFi disconnect, since the later one now won't be able to work.