### PR TITLE
allow image_buffer to be null in display_show_msg 

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -599,7 +599,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
     bbep.allocBuffer(false);
     bbep.fillScreen(BBEP_WHITE); // white background
 #endif
-    if (*(uint16_t *)image_buffer == BB_BITMAP_MARKER)
+    if (image_buffer && *(uint16_t *)image_buffer == BB_BITMAP_MARKER)
     {
         // G5 compressed image
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
@@ -610,7 +610,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
     else
     {
 #ifdef BB_EPAPER
-        memcpy(bbep.getBuffer(), image_buffer+62, Imagesize); // uncompressed 1-bpp bitmap
+        if (image_buffer) memcpy(bbep.getBuffer(), image_buffer+62, Imagesize); // uncompressed 1-bpp bitmap
 #endif
     }
 
@@ -821,7 +821,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Log_info("show image for array");
 
     // Load the image into the bb_epaper framebuffer
-    if (*(uint16_t *)image_buffer == BB_BITMAP_MARKER)
+    if (image_buffer && *(uint16_t *)image_buffer == BB_BITMAP_MARKER)
     {
         // G5 compressed image
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
@@ -832,7 +832,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     else
     {
 #ifdef BB_EPAPER
-        memcpy(bbep.getBuffer(), image_buffer+62, Imagesize); // uncompressed 1-bpp bitmap
+        if (image_buffer) memcpy(bbep.getBuffer(), image_buffer+62, Imagesize); // uncompressed 1-bpp bitmap
 #endif
     }
 


### PR DESCRIPTION
it allows to test display_show_msg for correct messages/layout without any change elsewhere (no include needed or rerferencece to a memory bitmap).
<img width="706" height="172" alt="image" src="https://github.com/user-attachments/assets/2281d4a6-aced-40de-a0a7-a328cdf6919a" />

I usually call dipslay_show_msg from display_show_image, bit being resilient to nullptr image makes these function more reobust anyway.
