### PR TITLE
fix for PNG payload > 48062 and malloc/free removed

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -238,10 +238,9 @@ void bl_init(void)
   {
     Log.info("%s [%d]: Display TRMNL logo start\r\n", __FILE__, __LINE__);
 
-    buffer = (uint8_t *)malloc(DEFAULT_IMAGE_SIZE);
+  
     display_show_image(storedLogoOrDefault(1), DEFAULT_IMAGE_SIZE, false);
-    free(buffer);
-    buffer = nullptr;
+
 
     need_to_refresh_display = 1;
     preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
@@ -1669,8 +1668,6 @@ static void getDeviceCredentials()
                 // show the image
                 String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
                 display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-                free(buffer);
-                buffer = nullptr;
                 need_to_refresh_display = 0;
               }
               else
@@ -2055,24 +2052,15 @@ static void writeSpecialFunction(SPECIAL_FUNCTION function)
   }
 }
 
-static void showMessageWithLogo(MSG message_type)
-{
-  buffer = (uint8_t *)malloc(DEFAULT_IMAGE_SIZE);
+static void showMessageWithLogo(MSG message_type) {
   display_show_msg(storedLogoOrDefault(0), message_type);
-  free(buffer);
-  buffer = nullptr;
-
   need_to_refresh_display = 1;
   preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
 }
 
 static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message)
 {
-  buffer = (uint8_t *)malloc(DEFAULT_IMAGE_SIZE);
   display_show_msg(storedLogoOrDefault(0), message_type, friendly_id, id, fw_version, message);
-  free(buffer);
-  buffer = nullptr;
-
   need_to_refresh_display = 1;
   preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
 }
@@ -2085,11 +2073,7 @@ static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, c
  */
 static void showMessageWithLogo(MSG message_type, const ApiSetupResponse &apiResponse)
 {
-  buffer = (uint8_t *)malloc(DEFAULT_IMAGE_SIZE);
   display_show_msg(storedLogoOrDefault(0), message_type, "", false, "", apiResponse.message);
-  free(buffer);
-  buffer = nullptr;
-
   need_to_refresh_display = 1;
   preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -480,7 +480,7 @@ PNG *png = new PNG();
 void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
 
 {
-    bool isPNG = true;
+    bool isPNG = data_size >= 4 && MOTOLONG(image_buffer) == (int32_t)0x89504e47;;
     auto width = display_width();
     auto height = display_height();
 //    uint32_t *d32;
@@ -607,7 +607,6 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
-    bbep.fillScreen(BBEP_WHITE); // white background
 #endif
     if (*(uint16_t *)image_buffer == BB_BITMAP_MARKER)
     {
@@ -615,6 +614,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
         int x = (width - pBBB->width)/2;
         int y = (height - pBBB->height)/2; // center it
+        if (x > 0 || y > 0) // only center if the image is smaller than the display
+        {
+            bbep.fillScreen(BBEP_WHITE); // draw the image centered on a white background
+        }
         bbep.loadG5Image(image_buffer, x, y, BBEP_WHITE, BBEP_BLACK);
     }
     else
@@ -807,7 +810,6 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
-    bbep.fillScreen(BBEP_WHITE);
     Log_info("Free heap after bbep.allocBuffer() - %d", ESP.getMaxAllocHeap());
 #endif
 
@@ -842,6 +844,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
         int x = (width - pBBB->width)/2;
         int y = (height - pBBB->height)/2; // center it
+        if (x > 0 || y > 0) // only center if the image is smaller than the display
+        { 
+            bbep.fillScreen(BBEP_WHITE);
+        }
         bbep.loadG5Image(image_buffer, x, y, BBEP_WHITE, BBEP_BLACK);
     }
     else

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -506,7 +506,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         }
     }
 #endif
-    if (isPNG == true && data_size < DEFAULT_IMAGE_SIZE)
+    if (isPNG == true && data_size < MAX_IMAGE_SIZE)
     {
         Log_info("Drawing PNG");
         iRefreshMode = png_to_epd(image_buffer, data_size);
@@ -523,11 +523,15 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
 #endif
             int x = (width - pBBB->width)/2;
             int y = (height - pBBB->height)/2; // center it
-            bbep.fillScreen(BBEP_WHITE); // draw the image centered on a white background
+            if (x > 0 || y > 0) // only clear if the image is smaller than the display
+            {
+                bbep.fillScreen(BBEP_WHITE); 
+            }     
             bbep.loadG5Image(image_buffer, x, y, BBEP_WHITE, BBEP_BLACK);
-        }
-        else
-        { // This work-around is due to a lack of RAM; the correct method would be to use loadBMP()
+        } 
+        else 
+        {
+         // This work-around is due to a lack of RAM; the correct method would be to use loadBMP()
             flip_image(image_buffer+62, bbep.width(), bbep.height(), false); // fix bottom-up bitmap images
 #ifdef BB_EPAPER
             bbep.setBuffer(image_buffer+62); // uncompressed 1-bpp bitmap
@@ -614,9 +618,9 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
         int x = (width - pBBB->width)/2;
         int y = (height - pBBB->height)/2; // center it
-        if (x > 0 || y > 0) // only center if the image is smaller than the display
+        if (x > 0 || y > 0) // only clear if the image is smaller than the display
         {
-            bbep.fillScreen(BBEP_WHITE); // draw the image centered on a white background
+            bbep.fillScreen(BBEP_WHITE); 
         }
         bbep.loadG5Image(image_buffer, x, y, BBEP_WHITE, BBEP_BLACK);
     }
@@ -844,7 +848,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         BB_BITMAP *pBBB = (BB_BITMAP *)image_buffer;
         int x = (width - pBBB->width)/2;
         int y = (height - pBBB->height)/2; // center it
-        if (x > 0 || y > 0) // only center if the image is smaller than the display
+        if (x > 0 || y > 0) // only clear if the image is smaller than the display
         { 
             bbep.fillScreen(BBEP_WHITE);
         }


### PR DESCRIPTION
Here are my propositions for the week-end\

- fix for PNG payload > 48062 reendered as static
- fix for G5 (small)logo processed as PNG (in loading screen)
- removal of most malloc/free  buffer in bl.cpp
- only clear screen when G5 bitmap is not fullscreen in display_show_msg x2)

