### PR TITLE
Color PNG support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -119,6 +119,7 @@ custom_include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_TRMNL
+        -D PNG_MAX_BUFFERED_PIXELS=6402
 
 [env:local]
 extends = env:trmnl

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@ default_envs = trmnl
 
 lib_deps =
 	bblanchon/ArduinoJson@7.4.1
-	bitbank2/PNGdec@1.1.3
+	https://github.com/bitbank2/PNGdec.git#62183bd9cb05b2f72656156b64c5192087de42fd
 
 ; Dependencies for all device builds
 [deps_app]
@@ -119,7 +119,7 @@ custom_include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_TRMNL
-        -D PNG_MAX_BUFFERED_PIXELS=6402
+	-D PNG_MAX_BUFFERED_PIXELS=6402
 
 [env:local]
 extends = env:trmnl

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -364,7 +364,7 @@ void ReduceBpp(int iDestBpp, int iPixelType, uint8_t *pPalette, uint8_t *pSrc, u
  * @param PNGDRAW structure containing the current line and relevant info
  * @return none
  */
-void png_draw(PNGDRAW *pDraw)
+int png_draw(PNGDRAW *pDraw)
 {
     int x;
     uint8_t ucBppChanged = 0, ucInvert = 0;
@@ -432,6 +432,7 @@ void png_draw(PNGDRAW *pDraw)
         }
     }
     bbep.writeData(pTemp, (pDraw->iWidth+7)/8);
+    return 1;
 } /* png_draw() */
 
 //
@@ -458,7 +459,7 @@ const uint8_t ucTwoBitFlags[256] = {
 0x09,0x0b,0x0d,0x09,0x0b,0x0a,0x0e,0x0a,0x0d,0x0e,0x0c,0x0c,0x09,0x0a,0x0c,0x08
 };
 
-void png_draw_count(PNGDRAW *pDraw)
+int png_draw_count(PNGDRAW *pDraw)
 {
     int x, *pFlags = (int *)pDraw->pUser;
     uint8_t *s, set_bits;
@@ -471,6 +472,7 @@ void png_draw_count(PNGDRAW *pDraw)
         set_bits |= ucTwoBitFlags[*s++]; // do 4 pixels at a time
     } // for x
     pFlags[0] = set_bits; // put it back in the flags array
+    return 1;
 } /* png_draw_count() */
 /** 
  * @brief Function to decode a PNG and count the number of unique colors

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -464,7 +464,7 @@ int png_draw_count(PNGDRAW *pDraw)
     int x, *pFlags = (int *)pDraw->pUser;
     uint8_t *s, set_bits;
 
-    if (pDraw->y > 430) return; // Workaround to ignore the icon in the lower left corner
+    if (pDraw->y > 430) return 0; // Workaround to ignore the icon in the lower left corner
 
     set_bits = pFlags[0]; // use a local var
     s = (uint8_t *)pDraw->pPixels;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -383,6 +383,8 @@ int png_draw(PNGDRAW *pDraw)
             ReduceBpp((pDraw->pUser) ? 2:1, pDraw->iPixelType, pDraw->pPalette, pDraw->pPixels, pTemp, pDraw->iWidth, pDraw->iBpp);
             ucBppChanged = 1;
         }
+    } else if (pDraw->iBpp == 2) {
+        ucInvert = 0xff; // 2-bit non-palette images need to be inverted colors for 4-gray mode
     }
     s = (ucBppChanged) ? pTemp : (uint8_t *)pDraw->pPixels;
     d = pTemp;


### PR DESCRIPTION
great for Alias, Redirect plugin use case. does use a bit more power, writeup coming soon.

1. point to a color image
2. just works

**requirements**
PNG, 800x480 (for now), < 90000 bytes. 

![color-png-support](https://github.com/user-attachments/assets/d77d3e7c-96ac-469f-9711-6a8aa7433c9f)
