### PR TITLE
Increment timeout counter on sleep to avoid infinite loop

### DIFF
--- a/lib/bb_epaper/src/bb_ep.inl
+++ b/lib/bb_epaper/src/bb_ep.inl
@@ -2133,6 +2133,7 @@ void bbepWaitBusy(BBEPDISP *pBBEP)
     while (iTimeout < 5000) {
         if (digitalRead(pBBEP->iBUSYPin) == busy_idle) break;
         // delay(1);
+        iTimeout += 200;
         bbepLightSleep(200); // save battery power by checking every 200ms
     }
 } /* bbepWaitBusy() */


### PR DESCRIPTION
I've run into some infinite loop conditions in this function, which looks like it's because of a missing increment of the loop counter.