### PR TITLE
Fix gas gauge measurements for X battery capacity

### DIFF
--- a/include/battery.h
+++ b/include/battery.h
@@ -70,6 +70,29 @@ public:
   int readCapacityFull() const { return _capacityFull; }     // mAh
 
 private:
+  /// @brief Performs a reset if the BQ27427 current-sensing resistor is
+  ///        specified with the wrong polarity, so Impedance Track relearns
+  ///        from scratch when the golden file is reloaded. Call BEFORE
+  ///        connectAndConfigure().
+  void resetIfPolarityInverted();
+
+  /// @brief Applies the correct polarity to the BQ27427 current-sensing
+  ///        resistor as-needed. Call AFTER connectAndConfigure(), since a
+  ///        reset/golden-file reload restores the inverted ROM default.
+  void correctCurrentPolarity();
+
+  /// @brief Checksum-verified read of one 32-byte gauge data-memory block in
+  ///        NORMAL mode, with the block-load settle delays the gauge needs.
+  bool readGaugeBlockVerified(uint8_t classID, uint8_t blockNum, uint8_t data[32]);
+
+  /// @brief The CC Cal byte holding the coulomb-counter sign (offset 5,
+  ///        bit 7), or -1 if it could not be read consistently.
+  int32_t readCCCalSignByte();
+
+  /// @brief Write the CC Cal sign byte through a CONFIG UPDATE session
+  ///        (TRM section 4.1 sequence) and verify it stuck.
+  bool writeCCCalSignByte(uint8_t value);
+
   int _soc = -1;
   int _health = -1;
   int _current = -1;

--- a/src/battery/bq27427_battery.cpp
+++ b/src/battery/bq27427_battery.cpp
@@ -25,11 +25,9 @@ static bool gaugeWrite(uint8_t reg, const uint8_t *data, uint8_t len) {
 static bool gaugeRead(uint8_t reg, uint8_t *data, uint8_t len) {
   Wire.beginTransmission(BQ27427_I2C_ADDRESS);
   Wire.write(reg);
-  if (Wire.endTransmission(true) != 0)
-    return false;
+  if (Wire.endTransmission(true) != 0) return false;
   uint8_t addr = BQ27427_I2C_ADDRESS;
-  if (Wire.requestFrom(addr, len) != len)
-    return false;
+  if (Wire.requestFrom(addr, len) != len) return false;
   for (uint8_t i = 0; i < len; i++)
     data[i] = Wire.read();
   return true;
@@ -46,6 +44,14 @@ static bool gaugeControl(uint16_t subcommand) {
   return gaugeWrite(0x00, cmd, 2);
 }
 
+// Reject implausible capacity readings, especially after first charging from a dead
+// battery. Expected capacity of 6000 or 12000 mAh ± 50%
+static bool isSaneCapacity(const BQ27427Snapshot &snap, bool oneCellPack) {
+  int expectedFull = oneCellPack ? 6000 : 12000; // design capacity × scale, mAh
+  if (snap.capacityFull < expectedFull / 2 || snap.capacityFull > expectedFull * 3 / 2) return false;
+  return snap.capacityRemain >= 0 && snap.capacityRemain <= snap.capacityFull;
+}
+
 void BQ27427Battery::gaugeInit() {
   if (battery_count == BATTERY_NONE) {
     Log_info("No battery detected - skipping BQ27427 initialization");
@@ -56,12 +62,10 @@ void BQ27427Battery::gaugeInit() {
 
   iqs323_task_i2c_lock();
 
-  // Early bq27427 batches ship with an inverted coulomb-counter calibration
-  // sign, making the gauge count discharge as charge: SOC climbs while
-  // draining and FullChargeCapacity is "learned" above design capacity.
-  // A gauge that has been running that way must be reset BEFORE
-  // connectAndConfigure(), so the resulting ITPOR triggers its golden-file
-  // reload and Impedance Track relearns from scratch.
+  // Some bq27427 ship with an inverted coulomb-counter calibration
+  // sign, making the gauge count discharge as charge. If so, the gauge
+  // must be reset BEFORE connectAndConfigure(), so the resulting ITPOR
+  // triggers its golden-file reload and Impedance Track relearns from scratch.
   if (lipo.begin(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL)) {
     resetIfPolarityInverted();
   }
@@ -73,6 +77,15 @@ void BQ27427Battery::gaugeInit() {
     correctCurrentPolarity();
   }
   bool readingsValid = ready && lipo.readSnapshot(snap);
+
+  if (readingsValid && !isSaneCapacity(snap, oneCellPack)) {
+    Log_warn("BQ27427: implausible capacities (RM/FCC=%d/%d mAh) - gauge learning is poisoned", snap.capacityRemain,
+             snap.capacityFull);
+    // full reset; will reload golden file as a result
+    lipo.reset();
+    delay(300); // POR + INITIALIZATION time before the gauge responds again
+    readingsValid = false;
+  }
 
   if (!readingsValid) {
     Log_warn("BQ27427: init failed or invalid readings (ready=%d) - resetting and retrying", ready);
@@ -86,7 +99,7 @@ void BQ27427Battery::gaugeInit() {
     if (ready) {
       correctCurrentPolarity();
     }
-    readingsValid = ready && lipo.readSnapshot(snap);
+    readingsValid = ready && lipo.readSnapshot(snap) && isSaneCapacity(snap, oneCellPack);
 
     if (!readingsValid) {
       Log_error("BQ27427: still not initialized or invalid readings after retry.");
@@ -145,15 +158,13 @@ bool BQ27427Battery::readGaugeBlockVerified(uint8_t classID, uint8_t blockNum, u
     if (!gaugeWrite(BQ27427_EXTENDED_CONTROL, &zero, 1)) // BlockDataControl(): enable access
       return false;
     delayMicroseconds(200);
-    if (!gaugeWrite(BQ27427_EXTENDED_DATACLASS, &classID, 1))
-      return false;
+    if (!gaugeWrite(BQ27427_EXTENDED_DATACLASS, &classID, 1)) return false;
     delayMicroseconds(200);
     gaugeWrite(BQ27427_EXTENDED_DATABLOCK, &blockNum, 1);
     delay(5); // allow the selected block to load into the BlockData() window
 
     uint8_t deviceCsum;
-    if (!gaugeRead(BQ27427_EXTENDED_BLOCKDATA, data, 32) ||
-        !gaugeRead(BQ27427_EXTENDED_CHECKSUM, &deviceCsum, 1))
+    if (!gaugeRead(BQ27427_EXTENDED_BLOCKDATA, data, 32) || !gaugeRead(BQ27427_EXTENDED_CHECKSUM, &deviceCsum, 1))
       continue;
 
     uint8_t csum = 0;
@@ -163,28 +174,24 @@ bool BQ27427Battery::readGaugeBlockVerified(uint8_t classID, uint8_t blockNum, u
 
     // A mismatch can mean a glitched read or the gauge updating the block
     // mid-read — retry either way
-    if (csum == deviceCsum)
-      return true;
+    if (csum == deviceCsum) return true;
   }
   return false;
 }
 
 int32_t BQ27427Battery::readCCCalSignByte() {
   uint8_t block[32];
-  if (!readGaugeBlockVerified(BQ27427_ID_CC_CAL, 0, block))
-    return -1;
+  if (!readGaugeBlockVerified(BQ27427_ID_CC_CAL, 0, block)) return -1;
   return block[5];
 }
 
 bool BQ27427Battery::writeCCCalSignByte(uint8_t value) {
   // Data memory update sequence from TRM section 4.1: enter CONFIG UPDATE,
   // select the block, replace the byte, commit via checksum, SOFT_RESET out.
-  if (!gaugeControl(BQ27427_CONTROL_SET_CFGUPDATE))
-    return false;
+  if (!gaugeControl(BQ27427_CONTROL_SET_CFGUPDATE)) return false;
   unsigned long t0 = millis();
   while (!(gaugeFlags() & BQ27427_FLAG_CFGUPMODE)) {
-    if (millis() - t0 > 2000)
-      return false; // never entered CONFIG UPDATE (sealed?)
+    if (millis() - t0 > 2000) return false; // never entered CONFIG UPDATE (sealed?)
     delay(10);
   }
 
@@ -199,8 +206,7 @@ bool BQ27427Battery::writeCCCalSignByte(uint8_t value) {
 
     // The block is still selected from the verified read above. Writing the
     // checksum to 0x60 is what commits the block to data memory.
-    wrote = gaugeWrite(BQ27427_EXTENDED_BLOCKDATA + 5, &value, 1) &&
-            gaugeWrite(BQ27427_EXTENDED_CHECKSUM, &csum, 1);
+    wrote = gaugeWrite(BQ27427_EXTENDED_BLOCKDATA + 5, &value, 1) && gaugeWrite(BQ27427_EXTENDED_CHECKSUM, &csum, 1);
     delay(10);
   }
 
@@ -208,8 +214,7 @@ bool BQ27427Battery::writeCCCalSignByte(uint8_t value) {
   gaugeControl(BQ27427_CONTROL_SOFT_RESET);
   t0 = millis();
   while (gaugeFlags() & BQ27427_FLAG_CFGUPMODE) {
-    if (millis() - t0 > 2000)
-      break;
+    if (millis() - t0 > 2000) break;
     delay(10);
   }
 
@@ -219,8 +224,7 @@ bool BQ27427Battery::writeCCCalSignByte(uint8_t value) {
 void BQ27427Battery::resetIfPolarityInverted() {
   int32_t ccSign = readCCCalSignByte();
   if (ccSign >= 0 && !(ccSign & 0x80)) {
-    Log_info("BQ27427: CC calibration sign OK (CC_CAL[5]=0x%02lX) - no reset required",
-             (unsigned long)ccSign);
+    Log_info("BQ27427: CC calibration sign OK (CC_CAL[5]=0x%02lX) - no reset required", (unsigned long)ccSign);
   } else if (ccSign >= 0 && !(gaugeFlags() & BQ27427_FLAG_ITPOR)) {
     // The gauge has been integrating with the wrong sign: everything it has
     // learned is untrustworthy.
@@ -238,8 +242,7 @@ void BQ27427Battery::correctCurrentPolarity() {
   } else if (ccSign & 0x80) {
     uint8_t corrected = (uint8_t)ccSign & 0x7F;
     if (writeCCCalSignByte(corrected)) {
-      Log_info("BQ27427: CC calibration sign corrected (0x%02lX -> 0x%02X)",
-               (unsigned long)ccSign, corrected);
+      Log_info("BQ27427: CC calibration sign corrected (0x%02lX -> 0x%02X)", (unsigned long)ccSign, corrected);
     } else {
       Log_error("BQ27427: CC calibration sign correction FAILED");
     }

--- a/src/battery/bq27427_battery.cpp
+++ b/src/battery/bq27427_battery.cpp
@@ -3,6 +3,7 @@
 #ifdef INCLUDE_BQ27427
 
 #include <Arduino.h>
+#include <Wire.h>
 #include <config.h>
 #include <display.h>
 #include <globals.h>
@@ -11,6 +12,39 @@
 #include "BQ27427.h"
 #include "driver/gpio.h"
 #include "iqs323_task.h"
+
+// Raw I2C helpers with error checking (the library's own transactions ignore
+// NACKs). The gauge shares the bus already initialized by lipo.begin().
+static bool gaugeWrite(uint8_t reg, const uint8_t *data, uint8_t len) {
+  Wire.beginTransmission(BQ27427_I2C_ADDRESS);
+  Wire.write(reg);
+  Wire.write(data, len);
+  return Wire.endTransmission(true) == 0;
+}
+
+static bool gaugeRead(uint8_t reg, uint8_t *data, uint8_t len) {
+  Wire.beginTransmission(BQ27427_I2C_ADDRESS);
+  Wire.write(reg);
+  if (Wire.endTransmission(true) != 0)
+    return false;
+  uint8_t addr = BQ27427_I2C_ADDRESS;
+  if (Wire.requestFrom(addr, len) != len)
+    return false;
+  for (uint8_t i = 0; i < len; i++)
+    data[i] = Wire.read();
+  return true;
+}
+
+static uint16_t gaugeFlags() {
+  uint8_t d[2] = {0xFF, 0xFF};
+  gaugeRead(BQ27427_COMMAND_FLAGS, d, 2);
+  return ((uint16_t)d[1] << 8) | d[0];
+}
+
+static bool gaugeControl(uint16_t subcommand) {
+  uint8_t cmd[2] = {(uint8_t)(subcommand & 0xFF), (uint8_t)(subcommand >> 8)};
+  return gaugeWrite(0x00, cmd, 2);
+}
 
 void BQ27427Battery::gaugeInit() {
   if (battery_count == BATTERY_NONE) {
@@ -22,8 +56,22 @@ void BQ27427Battery::gaugeInit() {
 
   iqs323_task_i2c_lock();
 
+  // Early bq27427 batches ship with an inverted coulomb-counter calibration
+  // sign, making the gauge count discharge as charge: SOC climbs while
+  // draining and FullChargeCapacity is "learned" above design capacity.
+  // A gauge that has been running that way must be reset BEFORE
+  // connectAndConfigure(), so the resulting ITPOR triggers its golden-file
+  // reload and Impedance Track relearns from scratch.
+  if (lipo.begin(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL)) {
+    resetIfPolarityInverted();
+  }
+
   BQ27427Snapshot snap;
   bool ready = lipo.connectAndConfigure(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL, oneCellPack);
+  if (ready) {
+    // A reset/golden-file reload restores the inverted ROM default sign
+    correctCurrentPolarity();
+  }
   bool readingsValid = ready && lipo.readSnapshot(snap);
 
   if (!readingsValid) {
@@ -35,6 +83,9 @@ void BQ27427Battery::gaugeInit() {
     iqs323_task_i2c_lock();
 
     ready = lipo.connectAndConfigure(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL, oneCellPack);
+    if (ready) {
+      correctCurrentPolarity();
+    }
     readingsValid = ready && lipo.readSnapshot(snap);
 
     if (!readingsValid) {
@@ -85,6 +136,113 @@ void BQ27427Battery::gaugeInit() {
     Log_info("BATTERY IS CHARGING");
   } else if (snap.flags & BQ27427_FLAG_DSG) {
     Log_info("BATTERY IS DISCHARGING");
+  }
+}
+
+bool BQ27427Battery::readGaugeBlockVerified(uint8_t classID, uint8_t blockNum, uint8_t data[32]) {
+  for (int attempt = 0; attempt < 3; attempt++) {
+    uint8_t zero = 0x00;
+    if (!gaugeWrite(BQ27427_EXTENDED_CONTROL, &zero, 1)) // BlockDataControl(): enable access
+      return false;
+    delayMicroseconds(200);
+    if (!gaugeWrite(BQ27427_EXTENDED_DATACLASS, &classID, 1))
+      return false;
+    delayMicroseconds(200);
+    gaugeWrite(BQ27427_EXTENDED_DATABLOCK, &blockNum, 1);
+    delay(5); // allow the selected block to load into the BlockData() window
+
+    uint8_t deviceCsum;
+    if (!gaugeRead(BQ27427_EXTENDED_BLOCKDATA, data, 32) ||
+        !gaugeRead(BQ27427_EXTENDED_CHECKSUM, &deviceCsum, 1))
+      continue;
+
+    uint8_t csum = 0;
+    for (int i = 0; i < 32; i++)
+      csum += data[i];
+    csum = 255 - csum;
+
+    // A mismatch can mean a glitched read or the gauge updating the block
+    // mid-read — retry either way
+    if (csum == deviceCsum)
+      return true;
+  }
+  return false;
+}
+
+int32_t BQ27427Battery::readCCCalSignByte() {
+  uint8_t block[32];
+  if (!readGaugeBlockVerified(BQ27427_ID_CC_CAL, 0, block))
+    return -1;
+  return block[5];
+}
+
+bool BQ27427Battery::writeCCCalSignByte(uint8_t value) {
+  // Data memory update sequence from TRM section 4.1: enter CONFIG UPDATE,
+  // select the block, replace the byte, commit via checksum, SOFT_RESET out.
+  if (!gaugeControl(BQ27427_CONTROL_SET_CFGUPDATE))
+    return false;
+  unsigned long t0 = millis();
+  while (!(gaugeFlags() & BQ27427_FLAG_CFGUPMODE)) {
+    if (millis() - t0 > 2000)
+      return false; // never entered CONFIG UPDATE (sealed?)
+    delay(10);
+  }
+
+  bool wrote = false;
+  uint8_t block[32];
+  if (readGaugeBlockVerified(BQ27427_ID_CC_CAL, 0, block)) {
+    block[5] = value;
+    uint8_t csum = 0;
+    for (int i = 0; i < 32; i++)
+      csum += block[i];
+    csum = 255 - csum;
+
+    // The block is still selected from the verified read above. Writing the
+    // checksum to 0x60 is what commits the block to data memory.
+    wrote = gaugeWrite(BQ27427_EXTENDED_BLOCKDATA + 5, &value, 1) &&
+            gaugeWrite(BQ27427_EXTENDED_CHECKSUM, &csum, 1);
+    delay(10);
+  }
+
+  // Exit CONFIG UPDATE whether or not the write landed
+  gaugeControl(BQ27427_CONTROL_SOFT_RESET);
+  t0 = millis();
+  while (gaugeFlags() & BQ27427_FLAG_CFGUPMODE) {
+    if (millis() - t0 > 2000)
+      break;
+    delay(10);
+  }
+
+  return wrote && readCCCalSignByte() == value;
+}
+
+void BQ27427Battery::resetIfPolarityInverted() {
+  int32_t ccSign = readCCCalSignByte();
+  if (ccSign >= 0 && !(ccSign & 0x80)) {
+    Log_info("BQ27427: CC calibration sign OK (CC_CAL[5]=0x%02lX) - no reset required",
+             (unsigned long)ccSign);
+  } else if (ccSign >= 0 && !(gaugeFlags() & BQ27427_FLAG_ITPOR)) {
+    // The gauge has been integrating with the wrong sign: everything it has
+    // learned is untrustworthy.
+    Log_info("BQ27427: inverted CC calibration (CC_CAL[5]=0x%02lX) with learned state - resetting gauge",
+             (unsigned long)ccSign);
+    lipo.reset();
+    delay(300); // POR + INITIALIZATION time before the gauge responds again
+  }
+}
+
+void BQ27427Battery::correctCurrentPolarity() {
+  int32_t ccSign = readCCCalSignByte();
+  if (ccSign < 0) {
+    Log_error("BQ27427: could not read CC calibration - current polarity unverified");
+  } else if (ccSign & 0x80) {
+    uint8_t corrected = (uint8_t)ccSign & 0x7F;
+    if (writeCCCalSignByte(corrected)) {
+      Log_info("BQ27427: CC calibration sign corrected (0x%02lX -> 0x%02X)",
+               (unsigned long)ccSign, corrected);
+    } else {
+      Log_error("BQ27427: CC calibration sign correction FAILED");
+    }
   }
 }
 


### PR DESCRIPTION
See https://github.com/usetrmnl/core/issues/4116 for the complete saga and references

[BQ27427 Technical Reference Manual](https://www.ti.com/lit/ug/sluucd5b/sluucd5b.pdf?ts=1786546801302)

## Fixes applied so far:

1. This PR reads the `CC Cal` register from the BQ27427 and checks the sign of the `CC Gain` floating-point value. If it's wrong, it resets the IC, reloads the golden file, and finally applies the correct sign. On my device, it flips from the ROM default of -0.338979 to 0.338979

2. Also, I found during testing that the reported capacity was invalid after charging up a previously-dead device - it was reporting 60,000 mAh. So I added a sanity check that resets the IC if the capacity is really far out-of-whack.

## Still to do:

1. The battery capacity is draining too quickly - maybe by a 10x factor? After 18 hours of constant refresh (4,783 refreshes), [my 2-cell X](https://trmnl.com/admin/devices/45080) reported a drain of 7,940 mAh / 18 h ≈ 440 mA average, or about 1.7 mAh per refresh. That average current draw seems way too high. Also, the voltage only dropped from 4.25V to 4.15V.
2. leverage `BQ27427::currentPolarity()` and `BQ27427::changeCurrentPolarity()` instead!!

## Things I tried:

1. Scaling `CC Gain` by 1/10 (to 0.0338979) cause a cascade of other problems, e.g. IC would stay in sleep mode because the scaled current didn't meet the wake-up threshold. Seems like we shouldn't be messing with that calibration anyway, besides the sign flip.

## Things I didn't try yet:

1. Faking it out by just using the 6000 mAh golden file for 2 cells, and applying a 2x scale in software
3. A device with 1 cell

## Things to know:

1. TI uses a proprietary 4-byte floating-point format from Xemics, [example here](https://github.com/USCRPL/BQ34Z100G1-Driver/blob/afd5411ee0e02311b46cd7c7e277bbeab368231f/BQ34Z100.cpp#L494-L563)
4. Resetting the IC causes the `CC Cal` to be reloaded from ROM. So we need to flip the sign whenever we detect that it's wrong.
5. When the device reports a low battery %, the TRMNL server returns back a "low battery" image. Which is why you can see the voltage drop in `test 1` long after it was reported as "dead".

<img width="2936" height="816" alt="CleanShot 2026-08-13 at 09 08 39@2x" src="https://github.com/user-attachments/assets/9674a46c-f98f-4096-91f4-76badf549fcc" />
