### PR TITLE
Add user-triggered shipping mode for reTerminal E1001/E1003

### DIFF
--- a/include/button.h
+++ b/include/button.h
@@ -1,5 +1,13 @@
-enum ButtonPressResult { LongPress, DoubleClick, ShortPress, SoftReset, NoAction };
-extern const char *ButtonPressResultNames[4];
+enum ButtonPressResult
+{
+  LongPress,
+  DoubleClick,
+  ShortPress,
+  SoftReset,
+  ShipMode,
+  NoAction
+};
+extern const char *ButtonPressResultNames[5];
 
 ButtonPressResult read_button_presses();
 

--- a/include/button.h
+++ b/include/button.h
@@ -1,12 +1,4 @@
-enum ButtonPressResult
-{
-  LongPress,
-  DoubleClick,
-  ShortPress,
-  SoftReset,
-  ShipMode,
-  NoAction
-};
+enum ButtonPressResult { LongPress, DoubleClick, ShortPress, SoftReset, ShipMode, NoAction };
 extern const char *ButtonPressResultNames[5];
 
 ButtonPressResult read_button_presses();

--- a/include/config.h
+++ b/include/config.h
@@ -137,17 +137,17 @@
 #define PIN_VBAT_SWITCH   6 // load switch enable pin for battery voltage measurement
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #elif defined(BOARD_SEEED_RETERMINAL_E1001)
-#define DEVICE_MODEL      "reterminal_e1001"
-#define PIN_INTERRUPT     3 // the green button
-#define PIN_VBAT_SWITCH   21 // load switch enable pin for battery voltage measurement
-#define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
-#define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
-#define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define DEVICE_MODEL        "reterminal_e1001"
+#define PIN_INTERRUPT       3 // the green button
+#define PIN_VBAT_SWITCH     21 // load switch enable pin for battery voltage measurement
+#define VBAT_SWITCH_LEVEL   HIGH // load switch enable pin active level
+#define PIN_BUZZER          45          // passive buzzer (MLT-8530) via NPN transistor
+#define BUZZER_FREQ         2700       // resonant frequency of MLT-8530 in Hz
 #define SHIP_MODE_SUPPORTED    // user-triggered shipping mode via 30 s button hold
 #define CHARGER_SY6974         // SY6974B I2C charger PMIC
-#define CHARGER_I2C_BUS Wire1  // SY6974B sits on I2C1
-#define CHARGER_I2C_SDA 39
-#define CHARGER_I2C_SCL 40
+#define CHARGER_I2C_BUS     Wire1  // SY6974B sits on I2C1
+#define CHARGER_I2C_SDA     39
+#define CHARGER_I2C_SCL     40
 #elif defined(BOARD_SEEED_RETERMINAL_E1002)
 #define DEVICE_MODEL      "reterminal_e1002"
 #define PIN_INTERRUPT     3 // the green button
@@ -157,17 +157,17 @@
 #define DEVICE_MODEL  "reTerminal Sticky"
 #define PIN_INTERRUPT 4 // the power button
 #elif defined(BOARD_SEEED_RETERMINAL_E1003)
-#define PIN_INTERRUPT     3 // green button
-#define PIN_VBAT_SWITCH   40
-#define VBAT_SWITCH_LEVEL HIGH
-#define DEVICE_MODEL      "reterminal_e1003"
-#define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
-#define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define PIN_INTERRUPT       3 // green button
+#define PIN_VBAT_SWITCH     40
+#define VBAT_SWITCH_LEVEL   HIGH
+#define DEVICE_MODEL        "reterminal_e1003"
+#define PIN_BUZZER          45          // passive buzzer (MLT-8530) via NPN transistor
+#define BUZZER_FREQ         2700       // resonant frequency of MLT-8530 in Hz
 #define SHIP_MODE_SUPPORTED    // user-triggered shipping mode via 30 s button hold
 #define CHARGER_SY6974         // SY6974B I2C charger PMIC
-#define CHARGER_I2C_BUS Wire   // SY6974B sits on I2C0 (shared with RTC / sensor)
-#define CHARGER_I2C_SDA 19
-#define CHARGER_I2C_SCL 20
+#define CHARGER_I2C_BUS     Wire   // SY6974B sits on I2C0 (shared with RTC / sensor)
+#define CHARGER_I2C_SDA     19
+#define CHARGER_I2C_SCL     20
 #endif
 
 // DHCP hostname prefix (hyphens instead of spaces).

--- a/include/config.h
+++ b/include/config.h
@@ -143,6 +143,11 @@
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
 #define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define SHIP_MODE_SUPPORTED    // user-triggered shipping mode via 30 s button hold
+#define CHARGER_SY6974         // SY6974B I2C charger PMIC
+#define CHARGER_I2C_BUS Wire1  // SY6974B sits on I2C1
+#define CHARGER_I2C_SDA 39
+#define CHARGER_I2C_SCL 40
 #elif defined(BOARD_SEEED_RETERMINAL_E1002)
 #define DEVICE_MODEL      "reterminal_e1002"
 #define PIN_INTERRUPT     3 // the green button
@@ -156,6 +161,13 @@
 #define PIN_VBAT_SWITCH   40
 #define VBAT_SWITCH_LEVEL HIGH
 #define DEVICE_MODEL      "reterminal_e1003"
+#define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
+#define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define SHIP_MODE_SUPPORTED    // user-triggered shipping mode via 30 s button hold
+#define CHARGER_SY6974         // SY6974B I2C charger PMIC
+#define CHARGER_I2C_BUS Wire   // SY6974B sits on I2C0 (shared with RTC / sensor)
+#define CHARGER_I2C_SDA 19
+#define CHARGER_I2C_SCL 20
 #endif
 
 // DHCP hostname prefix (hyphens instead of spaces).
@@ -183,6 +195,7 @@
 #define BUTTON_HOLD_TIME                   5000
 #define BUTTON_MEDIUM_HOLD_TIME            1000
 #define BUTTON_SOFT_RESET_TIME             15000
+#define BUTTON_SHIP_MODE_TIME              30000
 #define BUTTON_DOUBLE_CLICK_WINDOW         800
 
 #define SERVER_MAX_RETRIES                 3

--- a/include/ship_mode.h
+++ b/include/ship_mode.h
@@ -1,0 +1,21 @@
+#ifndef SHIP_MODE_H
+#define SHIP_MODE_H
+
+#include <config.h>
+
+#ifdef SHIP_MODE_SUPPORTED
+
+// Runs the full user-triggered shipping-mode handshake: prompt the user to
+// unplug USB, show the shipping screen, then enter a low-power sleep until a
+// charger is reconnected, at which point the device marks shipment complete and
+// restarts into normal operation. This call does not return.
+void enter_ship_mode();
+
+// Must be called early in setup() on ship-mode boards. If a shipment is in
+// progress it either completes it (charger present / button pressed) or returns
+// the device to deep sleep. May not return.
+void ship_mode_boot_check();
+
+#endif // SHIP_MODE_SUPPORTED
+
+#endif // SHIP_MODE_H

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -139,6 +139,12 @@ static void setWiFiBand(const WifiCredentials &credentials) {
 #endif
 }
 
+static std::function<void()> s_connectTickCallback = nullptr;
+
+void setConnectTickCallback(std::function<void()> cb) {
+  s_connectTickCallback = cb;
+}
+
 void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *eventData) {
   switch (event) {
   case ARDUINO_EVENT_WIFI_STA_GOT_IP:
@@ -374,6 +380,10 @@ wl_status_t waitForConnectResult(uint32_t timeout) {
   wl_status_t status = WiFi.status();
 
   while (millis() < timeoutmillis) {
+    if (s_connectTickCallback) {
+      s_connectTickCallback();
+    }
+
     wl_status_t newStatus = WiFi.status();
     if (newStatus != status) {
       Log_info("WiFi: status changed from %s to %s", wifiStatusStr(status), wifiStatusStr(newStatus));

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -141,9 +141,7 @@ static void setWiFiBand(const WifiCredentials &credentials) {
 
 static std::function<void()> s_connectTickCallback = nullptr;
 
-void setConnectTickCallback(std::function<void()> cb) {
-  s_connectTickCallback = cb;
-}
+void setConnectTickCallback(std::function<void()> cb) { s_connectTickCallback = cb; }
 
 void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *eventData) {
   switch (event) {

--- a/lib/wificaptive/src/connect.h
+++ b/lib/wificaptive/src/connect.h
@@ -1,10 +1,15 @@
 #pragma once
 
 #include <WiFiType.h>
-
+#include <functional>
 #include "wifi-helpers.h"
 #include "wifi-types.h"
 
 WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials);
 wl_status_t waitForConnectResult(uint32_t timeout);
 void disableWpa2Enterprise();
+
+// Registers a callback that is invoked repeatedly while waiting for a WiFi
+// connection to complete. Lets the caller poll hardware (e.g. the button) during
+// the otherwise blocking connect attempt. Pass nullptr to clear.
+void setConnectTickCallback(std::function<void()> cb);

--- a/lib/wificaptive/src/connect.h
+++ b/lib/wificaptive/src/connect.h
@@ -2,6 +2,7 @@
 
 #include <WiFiType.h>
 #include <functional>
+
 #include "wifi-helpers.h"
 #include "wifi-types.h"
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -10,6 +10,7 @@
 #include <types.h>
 #include <ArduinoLog.h>
 #include <WifiCaptive.h>
+#include <connect.h>
 #include <pins.h>
 #include <config.h>
 #include <HTTPClient.h>
@@ -27,6 +28,7 @@
 #include <filesystem.h>
 #include <stored_logs.h>
 #include <button.h>
+#include "ship_mode.h"
 #include "api-client/submit_log.h"
 #include <api-client/setup.h>
 #include <special_function.h>
@@ -714,6 +716,44 @@ void process_iqs323_data(void)
 // ############################ Gas gauge #############################
 #endif
 
+#ifndef BOARD_TRMNL_X
+// Poll the physical button while the (blocking) WiFi auto-connect is running so
+// the user can reset WiFi / credentials or enter shipping mode even when the
+// device is stuck retrying a missing access point. Mirrors the GPIO-wakeup
+// button handling in bl_init().
+static void wifi_connect_button_tick(void)
+{
+  pinMode(PIN_INTERRUPT, INPUT);
+  if (digitalRead(PIN_INTERRUPT) != LOW) {
+    return;
+  }
+
+  ButtonPressResult button = read_button_presses();
+  Log_info("Button during WiFi connect -> %s", ButtonPressResultNames[button]);
+  switch (button)
+  {
+  case LongPress:
+    Log_info("WiFi reset (button held during connect)");
+    WifiCaptivePortal.resetSettings();
+    ESP.restart();
+    break;
+  case SoftReset:
+    resetDeviceCredentials(); // clears credentials and restarts
+    break;
+#ifdef SHIP_MODE_SUPPORTED
+  case ShipMode:
+    enter_ship_mode(); // does not return
+    break;
+#endif
+  case DoubleClick:
+  case ShortPress:
+  case NoAction:
+  default:
+    break;
+  }
+}
+#endif // BOARD_TRMNL_X
+
 /**
  * @brief Function to init business logic module
  * @param none
@@ -818,6 +858,14 @@ void bl_init(void)
       break;
     case SoftReset:
       resetDeviceCredentials();
+      break;
+#ifdef SHIP_MODE_SUPPORTED
+    case ShipMode:
+      enter_ship_mode(); // does not return
+      break;
+#endif
+    default:
+      break;
     }
     Log_info("button handling end");
   }
@@ -1192,7 +1240,15 @@ void bl_init(void)
   {
     // WiFi saved, connection
     Log.info("%s [%d]: WiFi saved\r\n", __FILE__, __LINE__);
+#ifndef BOARD_TRMNL_X
+    // Poll the button during the blocking auto-connect so a hold can reset WiFi
+    // or enter shipping mode even while stuck retrying a missing access point.
+    setConnectTickCallback(wifi_connect_button_tick);
+#endif // BOARD_TRMNL_X
     int connection_res = connectWithSavedCredentials() ? 1 : 0;
+#ifndef BOARD_TRMNL_X
+    setConnectTickCallback(nullptr);
+#endif // BOARD_TRMNL_X
 
     Log.info("%s [%d]: Connection result: %d, WiFI Status: %d\r\n", __FILE__, __LINE__, connection_res, WiFi.status());
 
@@ -1260,6 +1316,30 @@ void bl_init(void)
       iqs323_task_i2c_unlock();
     });
 #endif
+#ifdef SHIP_MODE_SUPPORTED
+    // Allow entering shipping mode (30 s hold) or resetting credentials (15 s hold)
+    // from the setup portal by holding the green button (staged beeps at 5 / 15 / 30 s).
+    // read_button_presses() blocks until release and drives the beep feedback.
+    WifiCaptivePortal.setPortalTickCallback([]() {
+      pinMode(PIN_INTERRUPT, INPUT);
+      if (digitalRead(PIN_INTERRUPT) != LOW) {
+        return;
+      }
+      ButtonPressResult button = read_button_presses();
+      Log_info("Button during setup portal -> %s", ButtonPressResultNames[button]);
+      switch (button)
+      {
+      case SoftReset:
+        resetDeviceCredentials(); // clears credentials and restarts
+        break;
+      case ShipMode:
+        enter_ship_mode(); // does not return
+        break;
+      default:
+        break;
+      }
+    });
+#endif // SHIP_MODE_SUPPORTED
     WifiCaptivePortal.setResetSettingsCallback(resetDeviceCredentials);
     res = WifiCaptivePortal.startPortal();
     if (!res)

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -8,6 +8,36 @@
 
 static unsigned long wait_for_button_release(unsigned long start_time) {
   pinMode(PIN_INTERRUPT, INPUT);
+#ifdef SHIP_MODE_SUPPORTED
+  // Boards that support user-triggered shipping mode allow the hold to run all
+  // the way to BUTTON_SHIP_MODE_TIME. Feedback is staged during the hold:
+  //   5 s  -> 2 beeps (long press / WiFi reset)
+  //   15 s -> 3 beeps (soft reset / credentials reset)
+  //   30 s -> 4 beeps (shipping mode)
+  bool hold_buzzer_fired = false;
+  bool soft_reset_buzzer_fired = false;
+  while (digitalRead(PIN_INTERRUPT) == LOW && millis() - start_time < BUTTON_SHIP_MODE_TIME) {
+    unsigned long held = millis() - start_time;
+    if (!hold_buzzer_fired && held >= BUTTON_HOLD_TIME) {
+      buzzer().beepPattern(2, 100, 100);
+      hold_buzzer_fired = true;
+    }
+    if (!soft_reset_buzzer_fired && held >= BUTTON_SOFT_RESET_TIME) {
+      buzzer().beepPattern(3, 100, 100);
+      soft_reset_buzzer_fired = true;
+    }
+    delay(10);
+  }
+  if (millis() - start_time >= BUTTON_SHIP_MODE_TIME) {
+    // Shipping-mode threshold reached, four beeps to signal the user can release.
+    buzzer().beepPattern(4, 120, 120);
+  } else if (!hold_buzzer_fired) {
+    // Single beep on release for a short press (e.g. the refresh trigger), unless
+    // the longer hold pattern already fired.
+    buzzer().beep(100);
+  }
+  return millis() - start_time;
+#else
   bool hold_buzzer_fired = false;
   while (digitalRead(PIN_INTERRUPT) == LOW && millis() - start_time < BUTTON_SOFT_RESET_TIME) {
     if (!hold_buzzer_fired && millis() - start_time >= BUTTON_HOLD_TIME) {
@@ -17,12 +47,24 @@ static unsigned long wait_for_button_release(unsigned long start_time) {
     delay(10);
   }
   if (millis() - start_time >= BUTTON_SOFT_RESET_TIME) {
+    // Soft reset threshold reached, triple beep to signal the user can release.
     buzzer().beepPattern(3, 100, 100);
+  } else if (!hold_buzzer_fired) {
+    // Single beep on release for a short press (e.g. the refresh trigger), unless
+    // the longer hold pattern already fired.
+    buzzer().beep(100);
   }
   return millis() - start_time;
+#endif // SHIP_MODE_SUPPORTED
 }
 
 static ButtonPressResult classify_press_duration(unsigned long duration) {
+#ifdef SHIP_MODE_SUPPORTED
+  if (duration >= BUTTON_SHIP_MODE_TIME) {
+    Log_info("Button time=%lu detected ship-mode press", duration);
+    return ShipMode;
+  }
+#endif
   if (duration >= BUTTON_SOFT_RESET_TIME) {
     Log_info("Button time=%lu detected extra-long press", duration);
     return SoftReset;
@@ -91,11 +133,14 @@ static ButtonPressResult classify_button_presses() {
 }
 
 ButtonPressResult read_button_presses() {
-  auto result = classify_button_presses();
-  if (result == ShortPress || result == DoubleClick) {
-    buzzer().beep(100);
-  }
-  return result;
+  // Short-press feedback is emitted immediately on release inside
+  // wait_for_button_release(), so no additional beep is needed here.
+  return classify_button_presses();
 }
 
-const char *ButtonPressResultNames[] = {"LongPress", "DoubleClick", "ShortPress", "SoftReset"};
+const char *ButtonPressResultNames[] = {
+    "LongPress",
+    "DoubleClick",
+    "ShortPress",
+    "SoftReset",
+    "ShipMode"};

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -138,9 +138,4 @@ ButtonPressResult read_button_presses() {
   return classify_button_presses();
 }
 
-const char *ButtonPressResultNames[] = {
-    "LongPress",
-    "DoubleClick",
-    "ShortPress",
-    "SoftReset",
-    "ShipMode"};
+const char *ButtonPressResultNames[] = {"LongPress", "DoubleClick", "ShortPress", "SoftReset", "ShipMode"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
 #include <Arduino.h>
 
 #include "bl.h"
+#include "display.h"
 #include "esp_ota_ops.h"
 #include "power.h"
 #include "qa.h"
-#include "display.h"
 #include "ship_mode.h"
 
 #ifdef BOARD_TRMNL_X
@@ -68,8 +68,7 @@ void setup() {
   bl_init();
 }
 #else // TRMNL OG setup()
-void setup()
-{
+void setup() {
 #ifdef SHIP_MODE_SUPPORTED
   // Resume or complete an in-progress shipment. On each boot this either
   // finishes shipping (charger present or the user pressed the button) or sends

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include "esp_ota_ops.h"
 #include "power.h"
 #include "qa.h"
+#include "display.h"
+#include "ship_mode.h"
 
 #ifdef BOARD_TRMNL_X
 #include "display.h"
@@ -66,7 +68,14 @@ void setup() {
   bl_init();
 }
 #else // TRMNL OG setup()
-void setup() {
+void setup()
+{
+#ifdef SHIP_MODE_SUPPORTED
+  // Resume or complete an in-progress shipment. On each boot this either
+  // finishes shipping (charger present or the user pressed the button) or sends
+  // the device back to deep sleep while it waits. May not return.
+  ship_mode_boot_check();
+#endif // SHIP_MODE_SUPPORTED
 
   bool testPassed = checkIfAlreadyPassed();
   if (!testPassed) {

--- a/src/ship_mode.cpp
+++ b/src/ship_mode.cpp
@@ -3,14 +3,15 @@
 #ifdef SHIP_MODE_SUPPORTED
 
 #include <Arduino.h>
-#include <Wire.h>
 #include <WiFi.h>
-#include "esp_sleep.h"
-#include "trmnl_log.h"
+#include <Wire.h>
+
 #include "display.h"
-#include "ship_mode.h"
+#include "esp_sleep.h"
 #include "logo_medium.h"
 #include "qa.h"
+#include "ship_mode.h"
+#include "trmnl_log.h"
 
 // SY6974B I2C charger PMIC (shared by reTerminal E1001 and E1003). Only the
 // status register is needed here to know whether USB / charger power is present.
@@ -18,8 +19,8 @@
 #define CHARGER_I2C_ADDR 0x6B // SY6974B 7-bit I2C address
 #endif
 
-#define SY6974_REG_STATUS 0x08 // REG08: system status register
-#define SY6974_PG_STAT    0x04 // REG08[2] = 1 when VBUS power is good
+#define SY6974_REG_STATUS     0x08 // REG08: system status register
+#define SY6974_PG_STAT        0x04 // REG08[2] = 1 when VBUS power is good
 #define SY6974_VBUS_STAT_MASK 0xE0 // REG08[7:5] = input source (0 = no input)
 
 // How long to deep-sleep between charger polls while in shipping mode.
@@ -29,150 +30,143 @@
 
 static bool s_charger_bus_started = false;
 
-static void charger_bus_begin()
-{
-    if (s_charger_bus_started) {
-        return;
-    }
-    CHARGER_I2C_BUS.begin(CHARGER_I2C_SDA, CHARGER_I2C_SCL);
-    CHARGER_I2C_BUS.setClock(100000);
-    s_charger_bus_started = true;
+static void charger_bus_begin() {
+  if (s_charger_bus_started) {
+    return;
+  }
+  CHARGER_I2C_BUS.begin(CHARGER_I2C_SDA, CHARGER_I2C_SCL);
+  CHARGER_I2C_BUS.setClock(100000);
+  s_charger_bus_started = true;
 }
 
-static bool sy6974_read_reg(uint8_t reg, uint8_t *value)
-{
-    CHARGER_I2C_BUS.beginTransmission(CHARGER_I2C_ADDR);
-    CHARGER_I2C_BUS.write(reg);
-    if (CHARGER_I2C_BUS.endTransmission(false) != 0) {
-        return false;
-    }
-    if (CHARGER_I2C_BUS.requestFrom((int)CHARGER_I2C_ADDR, 1) != 1) {
-        return false;
-    }
-    *value = CHARGER_I2C_BUS.read();
-    return true;
+static bool sy6974_read_reg(uint8_t reg, uint8_t *value) {
+  CHARGER_I2C_BUS.beginTransmission(CHARGER_I2C_ADDR);
+  CHARGER_I2C_BUS.write(reg);
+  if (CHARGER_I2C_BUS.endTransmission(false) != 0) {
+    return false;
+  }
+  if (CHARGER_I2C_BUS.requestFrom((int)CHARGER_I2C_ADDR, 1) != 1) {
+    return false;
+  }
+  *value = CHARGER_I2C_BUS.read();
+  return true;
 }
 
 // Returns true only when the SY6974B reports an active VBUS input source
 // (REG08[7:5] VBUS_STAT != 0). The PG_STAT bit is NOT used: on the SY6974B it
 // stays asserted whenever the system rail is powered (including from battery),
 // so it cannot distinguish "plugged in" from "running on battery".
-bool check_usb_power()
-{
-    charger_bus_begin();
+bool check_usb_power() {
+  charger_bus_begin();
 
-    uint8_t status = 0;
-    if (!sy6974_read_reg(SY6974_REG_STATUS, &status)) {
-        Log_error("SY6974B: failed to read status register");
-        return false;
-    }
-    uint8_t vbus_stat = (status & SY6974_VBUS_STAT_MASK) >> 5;
-    Log_info("SY6974B REG08=0x%02X (PG=%d VBUS_STAT=%d)", status,
-             (status & SY6974_PG_STAT) ? 1 : 0, vbus_stat);
-    return vbus_stat != 0; // non-zero VBUS source = USB / charger present
+  uint8_t status = 0;
+  if (!sy6974_read_reg(SY6974_REG_STATUS, &status)) {
+    Log_error("SY6974B: failed to read status register");
+    return false;
+  }
+  uint8_t vbus_stat = (status & SY6974_VBUS_STAT_MASK) >> 5;
+  Log_info("SY6974B REG08=0x%02X (PG=%d VBUS_STAT=%d)", status, (status & SY6974_PG_STAT) ? 1 : 0, vbus_stat);
+  return vbus_stat != 0; // non-zero VBUS source = USB / charger present
 }
 
 // Deep-sleep until the next poll or a button press. Deep sleep keeps draw
 // minimal and guarantees a clean I2C re-init on the next boot. The e-paper
 // retains the shipping screen without power. Does not return.
-static void ship_mode_deep_sleep()
-{
+static void ship_mode_deep_sleep() {
     // Make sure the button is released first, otherwise the active-low ext0 wake
     // would fire immediately and look like a manual exit.
-    pinMode(PIN_INTERRUPT, INPUT);
-    while (digitalRead(PIN_INTERRUPT) == LOW) {
-        delay(10);
-    }
-    delay(50);
+  pinMode(PIN_INTERRUPT, INPUT);
+  while (digitalRead(PIN_INTERRUPT) == LOW) {
+    delay(10);
+  }
+  delay(50);
 
-    Log_info("Ship: deep sleeping (poll in %d s, or press button to exit)", SHIP_MODE_POLL_INTERVAL_S);
-    Serial.flush();
+  Log_info("Ship: deep sleeping (poll in %d s, or press button to exit)", SHIP_MODE_POLL_INTERVAL_S);
+  Serial.flush();
 
-    esp_sleep_enable_timer_wakeup((uint64_t)SHIP_MODE_POLL_INTERVAL_S * 1000000ULL);
+  esp_sleep_enable_timer_wakeup((uint64_t)SHIP_MODE_POLL_INTERVAL_S * 1000000ULL);
     // Green button (active low) as a manual wake / exit fallback.
-    esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+  esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 
-    esp_deep_sleep_start();
+  esp_deep_sleep_start();
 }
 
 // Called from setup() on every boot. If a shipment is in progress, either
 // complete it (charger present, or the user pressed the button to exit) or go
 // back to deep sleep to keep waiting. May not return.
-void ship_mode_boot_check()
-{
-    bool shipped = checkIfAlreadyShipped();
-    bool started = checkIfShipmentStarted();
-    Log_info("Ship boot check: ship_done=%d ship_started=%d cause=%d",
-             shipped, started, (int)esp_sleep_get_wakeup_cause());
-    if (shipped) {
-        return; // already shipped — normal boot
-    }
+void ship_mode_boot_check() {
+  bool shipped = checkIfAlreadyShipped();
+  bool started = checkIfShipmentStarted();
+  Log_info("Ship boot check: ship_done=%d ship_started=%d cause=%d", shipped, started,
+           (int)esp_sleep_get_wakeup_cause());
+  if (shipped) {
+    return; // already shipped — normal boot
+  }
 
-    if (!started) {
+  if (!started) {
         // Never shipped and no shipment in progress (e.g. freshly flashed at the
         // factory): default into shipping mode so the device can be boxed and
         // shipped. Completing the shipment (charger reconnect or button) sets
         // ship_done, so this only happens until the unit is first powered by the
         // customer.
-        Log_info("Ship boot check: defaulting into shipping mode after flash");
-        display_init();
-        enter_ship_mode(); // does not return
-    }
+    Log_info("Ship boot check: defaulting into shipping mode after flash");
+    display_init();
+    enter_ship_mode(); // does not return
+  }
 
-    esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
-    bool woke_by_button = (cause == ESP_SLEEP_WAKEUP_EXT0 || cause == ESP_SLEEP_WAKEUP_GPIO);
+  esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+  bool woke_by_button = (cause == ESP_SLEEP_WAKEUP_EXT0 || cause == ESP_SLEEP_WAKEUP_GPIO);
 
-    if (woke_by_button) {
-        Log_info("Ship: button wake — exiting shipping mode");
-        saveShipmentDone();
-        return; // continue normal boot
-    }
-    if (check_usb_power()) {
-        Log_info("Ship: charger detected — exiting shipping mode");
-        saveShipmentDone();
-        return; // continue normal boot
-    }
+  if (woke_by_button) {
+    Log_info("Ship: button wake — exiting shipping mode");
+    saveShipmentDone();
+    return; // continue normal boot
+  }
+  if (check_usb_power()) {
+    Log_info("Ship: charger detected — exiting shipping mode");
+    saveShipmentDone();
+    return; // continue normal boot
+  }
 
     // Still shipping and unplugged. On a fresh / brown-out boot (anything other
     // than our own timer poll) re-draw the shipping screen so the display is
     // correct, then go back to sleep.
-    if (cause != ESP_SLEEP_WAKEUP_TIMER) {
-        Log_info("Ship: resuming shipping mode after reset");
-        display_init();
-        display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
-    }
+  if (cause != ESP_SLEEP_WAKEUP_TIMER) {
+    Log_info("Ship: resuming shipping mode after reset");
+    display_init();
+    display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
+  }
 
-    ship_mode_deep_sleep(); // does not return
+  ship_mode_deep_sleep(); // does not return
 }
 
-void enter_ship_mode()
-{
-    Log_info("Entering shipping mode");
+void enter_ship_mode() {
+  Log_info("Entering shipping mode");
 
     // Persist shipment-in-progress immediately. Clear any stale "shipped" flag
     // from a previous shipment so this run isn't treated as already complete.
     // Removing USB can brown-out and reset the board before we reach deep sleep,
     // so this must be saved first — ship_mode_boot_check() resumes on next boot.
-    clearShipmentStatus();
-    saveShipmentStarted();
+  clearShipmentStatus();
+  saveShipmentStarted();
 
     // Stop the WiFi radio / setup soft-AP before settling into low-power sleep.
-    WiFi.disconnect(true);
-    WiFi.mode(WIFI_OFF);
+  WiFi.disconnect(true);
+  WiFi.mode(WIFI_OFF);
 
     // If USB is still plugged in, ask the user to unplug it first.
-    if (check_usb_power()) {
-        display_show_msg(const_cast<uint8_t *>(logo_medium), READY_TO_SHIP);
-        while (check_usb_power()) {
-            Log_info("USB still connected, waiting for unplug...");
-            delay(1000);
-        }
-        Log_info("USB unplugged");
+  if (check_usb_power()) {
+    display_show_msg(const_cast<uint8_t *>(logo_medium), READY_TO_SHIP);
+    while (check_usb_power()) {
+      Log_info("USB still connected, waiting for unplug...");
+      delay(1000);
     }
+    Log_info("USB unplugged");
+  }
 
-    display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
+  display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
 
-    ship_mode_deep_sleep(); // does not return
+  ship_mode_deep_sleep(); // does not return
 }
 
 #endif // SHIP_MODE_SUPPORTED

--- a/src/ship_mode.cpp
+++ b/src/ship_mode.cpp
@@ -1,0 +1,178 @@
+#include <config.h>
+
+#ifdef SHIP_MODE_SUPPORTED
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <WiFi.h>
+#include "esp_sleep.h"
+#include "trmnl_log.h"
+#include "display.h"
+#include "ship_mode.h"
+#include "logo_medium.h"
+#include "qa.h"
+
+// SY6974B I2C charger PMIC (shared by reTerminal E1001 and E1003). Only the
+// status register is needed here to know whether USB / charger power is present.
+#ifndef CHARGER_I2C_ADDR
+#define CHARGER_I2C_ADDR 0x6B // SY6974B 7-bit I2C address
+#endif
+
+#define SY6974_REG_STATUS 0x08 // REG08: system status register
+#define SY6974_PG_STAT    0x04 // REG08[2] = 1 when VBUS power is good
+#define SY6974_VBUS_STAT_MASK 0xE0 // REG08[7:5] = input source (0 = no input)
+
+// How long to deep-sleep between charger polls while in shipping mode.
+#ifndef SHIP_MODE_POLL_INTERVAL_S
+#define SHIP_MODE_POLL_INTERVAL_S 3
+#endif
+
+static bool s_charger_bus_started = false;
+
+static void charger_bus_begin()
+{
+    if (s_charger_bus_started) {
+        return;
+    }
+    CHARGER_I2C_BUS.begin(CHARGER_I2C_SDA, CHARGER_I2C_SCL);
+    CHARGER_I2C_BUS.setClock(100000);
+    s_charger_bus_started = true;
+}
+
+static bool sy6974_read_reg(uint8_t reg, uint8_t *value)
+{
+    CHARGER_I2C_BUS.beginTransmission(CHARGER_I2C_ADDR);
+    CHARGER_I2C_BUS.write(reg);
+    if (CHARGER_I2C_BUS.endTransmission(false) != 0) {
+        return false;
+    }
+    if (CHARGER_I2C_BUS.requestFrom((int)CHARGER_I2C_ADDR, 1) != 1) {
+        return false;
+    }
+    *value = CHARGER_I2C_BUS.read();
+    return true;
+}
+
+// Returns true only when the SY6974B reports an active VBUS input source
+// (REG08[7:5] VBUS_STAT != 0). The PG_STAT bit is NOT used: on the SY6974B it
+// stays asserted whenever the system rail is powered (including from battery),
+// so it cannot distinguish "plugged in" from "running on battery".
+bool check_usb_power()
+{
+    charger_bus_begin();
+
+    uint8_t status = 0;
+    if (!sy6974_read_reg(SY6974_REG_STATUS, &status)) {
+        Log_error("SY6974B: failed to read status register");
+        return false;
+    }
+    uint8_t vbus_stat = (status & SY6974_VBUS_STAT_MASK) >> 5;
+    Log_info("SY6974B REG08=0x%02X (PG=%d VBUS_STAT=%d)", status,
+             (status & SY6974_PG_STAT) ? 1 : 0, vbus_stat);
+    return vbus_stat != 0; // non-zero VBUS source = USB / charger present
+}
+
+// Deep-sleep until the next poll or a button press. Deep sleep keeps draw
+// minimal and guarantees a clean I2C re-init on the next boot. The e-paper
+// retains the shipping screen without power. Does not return.
+static void ship_mode_deep_sleep()
+{
+    // Make sure the button is released first, otherwise the active-low ext0 wake
+    // would fire immediately and look like a manual exit.
+    pinMode(PIN_INTERRUPT, INPUT);
+    while (digitalRead(PIN_INTERRUPT) == LOW) {
+        delay(10);
+    }
+    delay(50);
+
+    Log_info("Ship: deep sleeping (poll in %d s, or press button to exit)", SHIP_MODE_POLL_INTERVAL_S);
+    Serial.flush();
+
+    esp_sleep_enable_timer_wakeup((uint64_t)SHIP_MODE_POLL_INTERVAL_S * 1000000ULL);
+    // Green button (active low) as a manual wake / exit fallback.
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+
+    esp_deep_sleep_start();
+}
+
+// Called from setup() on every boot. If a shipment is in progress, either
+// complete it (charger present, or the user pressed the button to exit) or go
+// back to deep sleep to keep waiting. May not return.
+void ship_mode_boot_check()
+{
+    bool shipped = checkIfAlreadyShipped();
+    bool started = checkIfShipmentStarted();
+    Log_info("Ship boot check: ship_done=%d ship_started=%d cause=%d",
+             shipped, started, (int)esp_sleep_get_wakeup_cause());
+    if (shipped) {
+        return; // already shipped — normal boot
+    }
+
+    if (!started) {
+        // Never shipped and no shipment in progress (e.g. freshly flashed at the
+        // factory): default into shipping mode so the device can be boxed and
+        // shipped. Completing the shipment (charger reconnect or button) sets
+        // ship_done, so this only happens until the unit is first powered by the
+        // customer.
+        Log_info("Ship boot check: defaulting into shipping mode after flash");
+        display_init();
+        enter_ship_mode(); // does not return
+    }
+
+    esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+    bool woke_by_button = (cause == ESP_SLEEP_WAKEUP_EXT0 || cause == ESP_SLEEP_WAKEUP_GPIO);
+
+    if (woke_by_button) {
+        Log_info("Ship: button wake — exiting shipping mode");
+        saveShipmentDone();
+        return; // continue normal boot
+    }
+    if (check_usb_power()) {
+        Log_info("Ship: charger detected — exiting shipping mode");
+        saveShipmentDone();
+        return; // continue normal boot
+    }
+
+    // Still shipping and unplugged. On a fresh / brown-out boot (anything other
+    // than our own timer poll) re-draw the shipping screen so the display is
+    // correct, then go back to sleep.
+    if (cause != ESP_SLEEP_WAKEUP_TIMER) {
+        Log_info("Ship: resuming shipping mode after reset");
+        display_init();
+        display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
+    }
+
+    ship_mode_deep_sleep(); // does not return
+}
+
+void enter_ship_mode()
+{
+    Log_info("Entering shipping mode");
+
+    // Persist shipment-in-progress immediately. Clear any stale "shipped" flag
+    // from a previous shipment so this run isn't treated as already complete.
+    // Removing USB can brown-out and reset the board before we reach deep sleep,
+    // so this must be saved first — ship_mode_boot_check() resumes on next boot.
+    clearShipmentStatus();
+    saveShipmentStarted();
+
+    // Stop the WiFi radio / setup soft-AP before settling into low-power sleep.
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+
+    // If USB is still plugged in, ask the user to unplug it first.
+    if (check_usb_power()) {
+        display_show_msg(const_cast<uint8_t *>(logo_medium), READY_TO_SHIP);
+        while (check_usb_power()) {
+            Log_info("USB still connected, waiting for unplug...");
+            delay(1000);
+        }
+        Log_info("USB unplugged");
+    }
+
+    display_show_msg(const_cast<uint8_t *>(logo_medium), SHIPPING_MODE);
+
+    ship_mode_deep_sleep(); // does not return
+}
+
+#endif // SHIP_MODE_SUPPORTED

--- a/src/ship_mode.cpp
+++ b/src/ship_mode.cpp
@@ -99,19 +99,8 @@ void ship_mode_boot_check() {
   bool started = checkIfShipmentStarted();
   Log_info("Ship boot check: ship_done=%d ship_started=%d cause=%d", shipped, started,
            (int)esp_sleep_get_wakeup_cause());
-  if (shipped) {
-    return; // already shipped — normal boot
-  }
-
-  if (!started) {
-        // Never shipped and no shipment in progress (e.g. freshly flashed at the
-        // factory): default into shipping mode so the device can be boxed and
-        // shipped. Completing the shipment (charger reconnect or button) sets
-        // ship_done, so this only happens until the unit is first powered by the
-        // customer.
-    Log_info("Ship boot check: defaulting into shipping mode after flash");
-    display_init();
-    enter_ship_mode(); // does not return
+  if (shipped || !started) {
+    return; // no shipment in progress — normal boot
   }
 
   esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();


### PR DESCRIPTION
## Summary

Adds shipping mode for the Seeed reTerminal E1001/E1003 activated by holding the button for 30s and indicated by a series of four beeps.

These boards use the SY6974B I2C charger PMIC, so shipping mode reads its status register to detect whether USB/charger power is present.

## Staged button-feedback beeps

Extends the existing `buzzer()` interface with staged feedback during a hold, so the user hears each threshold:

| Hold | Beeps | Action |
|------|-------|--------|
| n/a | 1 | refresh |
| 5 s | 2 | long press |
| 15 s | 3 | soft reset |
| 30 s | 4 | shipping mode |

The beeps are a no-op on boards without a buzzer (base `BaseBuzzer`).

## Scope / notes

- Reuses the existing shipment helpers (`qa.cpp`) and `READY_TO_SHIP` / `SHIPPING_MODE` screens already in the tree.
- Gated by a new `SHIP_MODE_SUPPORTED` define (set only for E1001/E1003, alongside the `CHARGER_*` I2C config).
- No behavior change for boards without `SHIP_MODE_SUPPORTED`.

## Testing

Builds succeed for:

- `seeed_reTerminal_E1001`
- `TRMNL_X_E1003`
- `trmnl` (OG, to confirm the shared `button.cpp` change is a no-op regression-wise)
