### PR TITLE
Pin bb_epaper to the commit v1.8.0 shipped to fix the E1001 no-draw

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,11 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	bitbank2/PNGdec@1.1.6
 	bitbank2/JPEGDEC@1.8.4
-	bitbank2/bb_epaper@2.1.9
-;	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
+; bb_epaper: the exact commit v1.8.0 shipped. Registry 2.1.9 predates the
+; init/wakeup fix (bitbank2/bb_epaper@b504dfb) and leaves the Seeed E1001
+; panel dark (#502). The EP75 1-bit partial LUT drive values (the ghosting
+; surface behind 11589c9's downgrade) are unchanged vs 2.1.9; see PR.
+	https://github.com/bitbank2/bb_epaper.git#3d3df73aa25b5788acc7a62d8236f5129c812ede
 
 ; Dependencies for all device builds
 [deps_app]


### PR DESCRIPTION
Fixes #502.

I A/B tested this on a real E1001, on a v1.8.12 base with the serial console enabled and everything else identical. With bb_epaper registry 2.1.9 the firmware runs fine and the logs even report a complete draw, but the panel never shows anything, not even the boot screens. With `git#3d3df73`, the exact pin v1.8.0 shipped, everything draws. Official 1.8.10 for seeed_E1001 carries 2.1.9. That matches aserraric's report in #502. jjhelin's unit drew once right after flashing, which I can't fully explain.

From reading the code, 2.1.9 predates bitbank2/bb_epaper@b504dfb. Its `bbepInitIO()` still pulses RST and marks the panel awake itself, so the first command goes out without the `bbepWakeUp()` BUSY handshake. The OG panel tolerates that. The E1001's controller apparently doesn't. The pin history fits too. v1.8.0 shipped 3d3df73 and worked, the pin was lost in v1.8.1, and every release since has resolved to a library without b504dfb. The one exception is v1.8.11, and no E1001 binary of that was ever published.

I know 11589c9 pinned 2.1.9 deliberately to fix ghosting, so this PR does not bump to 2.1.10 or 2.1.11. The change that plausibly caused the ghosting is bitbank2/bb_epaper@bdcc227, first released in 2.1.10. It replaced the EP75 partial LUT that re-drives every pixel five times with a differential single pass, so unchanged pixels are never re-driven and ghosts accumulate. 3d3df73 predates it. Its 1-bit partial LUT drive values and `epd75_init_sequence_full` are byte-for-byte the same as in 2.1.9, so the behavior you pinned 2.1.9 for is preserved. The 4-gray tables and the gen2 partial table do change, since fixing those was the point of 3d3df73. The gen2 partial table is used by temp profile "a", so that one is worth a quick check on your hardware.

Longer term this wants a bb_epaper release that has today's fixes plus an EP75 partial waveform that doesn't ghost. That would also give xteink_x4 back the bb_epaper bump from #412, which the downgrade reverted. I opened bitbank2/bb_epaper#39 with the analysis. Both `trmnl` and `seeed_reTerminal_E1001` compile with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnbEJHrfQMVgshYATiSfMq
