### PR TITLE
Restore the lost v1.8.0 fix for swapped middle grays in EP75 4-gray mode

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1301,10 +1301,14 @@ int png_draw(PNGDRAW *pDraw)
                 }
             } // for x
         } else { // normal 0/1 split plane
-            ucMask = (iPlane == PNG_2_BIT_0) ? 0x40 : 0x80; // lower or upper source bit
+            const uint8_t ucTranslate[4] = {0, 2, 1, 3}; // translate grays to odd order of native 4-gray mode on 7.5" panel
+            const uint8_t ucNoTranslate[4] = {0, 1, 2, 3}; // for other 2-bit panels
+            uint8_t ucPT = bbep.getPanelType();
+            const uint8_t *pTranslate = (ucPT == EP75_800x480_4GRAY || ucPT == EP75_800x480_4GRAY_GEN2) ? ucTranslate : ucNoTranslate;
+            ucMask = (iPlane == PNG_2_BIT_0) ? 0x1 : 0x2; // lower or upper source bit
             for (x=0; x<iWidth; x++) {
                 uc <<= 1;
-                if (src & ucMask) {
+                if (pTranslate[src>>6] & ucMask) {
                     uc |= 1; // high bit of source pair
                 }
                 src <<= 2;


### PR DESCRIPTION
After v1.8.0, 2-bpp rendering on EP75 panels swaps the two middle gray levels. PNG level 1, the dark gray, renders lighter than level 2, the light gray. Black and white are correct, so it's easy to miss without a calibration chart.

The fix already exists. Commit 2ed5c80 added a translate table to the split-plane path of `png_draw()`, but that commit is reachable only from tag v1.8.0 and never made it into main. This PR takes just that rendering hunk, byte for byte. The rest of 2ed5c80, the temp profile plumbing, is also absent from main, but that's a separate question.

I verified this on an E1001, on a v1.8.12 base together with the bb_epaper pin from #563. Without the hunk the two middle bands of a 4-band chart render inverted, and with it all four bands come out in order. v1.8.0 was always correct on the same panel. It pairs with that PR, since today's 2.1.9 pin can't draw on the E1001 at all and its EP75 gray tables predate the 3d3df73 rewrite. Pin plus hunk is the combination that has actually been tested.

Two things are deliberately left out. Profile "b" (`EP75_800x480_4GRAY_V2`) keeps Larry's original two-panel check, because its LUT appears to encode the two mid-gray waveforms in swapped order already and translating there could swap them back. And `jpeg_draw()` has the same un-translated plane split, but that path is currently unreachable since the JPEG path hard-codes 1-bit dithered, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnbEJHrfQMVgshYATiSfMq
