### PR TITLE
Fix Wi-Fi ESP_ERR_WIFI_STOP_STATE (12308) reboot on network save/reset

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -56,15 +56,6 @@ bool WifiCaptive::startPortal() {
   WiFi.softAP(SSID.c_str(), WIFI_PASSWORD, WIFI_CHANNEL, 0, MAX_CLIENTS);
   delay(50);
 
-    // Disable AMPDU RX on the ESP32 WiFi to fix a bug on Android
-  esp_wifi_stop();
-  esp_wifi_deinit();
-  wifi_init_config_t my_config = WIFI_INIT_CONFIG_DEFAULT();
-  my_config.ampdu_rx_enable = false;
-  esp_wifi_init(&my_config);
-  esp_wifi_start();
-  vTaskDelay(100 / portTICK_PERIOD_MS); // Add a small delay
-
     // configure DSN and WEB server
   setUpDNSServer(*_dnsServer, localIP);
 
@@ -290,7 +281,7 @@ void WifiCaptive::resetSettings() {
     // Clean up any WPA2 Enterprise state
   disableWpa2Enterprise();
 
-  WiFi.disconnect(true, true);
+  WiFi.disconnect(false, true);
   WiFi.eraseAP();
 }
 

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -6,7 +6,7 @@
 #include <AsyncTCP.h> //https://github.com/me-no-dev/AsyncTCP using the latest dev version from @me-no-dev
 #include <DNSServer.h>
 #include <ESPAsyncWebServer.h> //https://github.com/me-no-dev/ESPAsyncWebServer using the latest dev version from @me-no-dev
-#include <esp_wifi.h> //Used for mpdu_rx_disable android workaround
+#include <esp_wifi.h>
 #include <functional>
 #include <vector>
 

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -197,7 +197,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
     }
 
         // configure WPA2 Enterprise
-    WiFi.mode(WIFI_STA);
+    WiFi.enableSTA(true);
     applyWifiHostname(WifiCaptivePortal.getHostname());
     WiFi.disconnect();
     delay(100);
@@ -262,7 +262,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
     Log_info("WiFi: WPA2 Enterprise configured, starting from status %s", wifiStatusStr(beginResult));
   } else {
         // regular connection
-    WiFi.mode(WIFI_STA);
+    WiFi.enableSTA(true);
 
     setWiFiBand(credentials);
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1168,7 +1168,7 @@ void bl_init(void)
     res = WifiCaptivePortal.startPortal();
     if (!res)
     {
-      WiFi.disconnect(true);
+      WiFi.disconnect();
 
       showMessageWithLogo(WIFI_FAILED);
 
@@ -1849,8 +1849,8 @@ static https_request_err_e downloadAndShow()
 
           submitStoredLogs();
 
-          WiFi.disconnect(true); // no need for WiFi, save power starting here
-          Log.info("%s [%d]: Received successfully; WiFi off.\r\n", __FILE__, __LINE__);
+          WiFi.disconnect();
+          Log.info("%s [%d]: Received successfully; WiFi disconnected.\r\n", __FILE__, __LINE__);
 
           bool image_reverse = false;
           if (isPNG || isJPEG)


### PR DESCRIPTION
## Problem

On ESP32-S3 devices, saving or resetting a Wi-Fi network could leave the radio unusable, with the boot log showing:

```
E (xxxxx) wifi_init_default: netstack cb reg failed with 12308
```

`12308` is `ESP_ERR_WIFI_STOP_STATE` ("Wi-Fi is stopping"). The captive portal and credential-reset paths stopped and reinitialized the ESP-IDF Wi-Fi driver behind the Arduino `WiFi` layer, so a subsequent boot or CPU reset could begin while a radio shutdown was still in progress. `esp_wifi_init()` then failed and Wi-Fi stayed down until another reset, sometimes looping through `RTC_SW_CPU_RST` / `RTCWDT_RTC_RST`.