### PR TITLE
Show setup screen when /api/setup returns no image URL

### DIFF
--- a/src/services/device_setup.cpp
+++ b/src/services/device_setup.cpp
@@ -18,7 +18,12 @@ DeviceSetupResult DeviceSetup::perform() {
   _result = DeviceSetupResult();
   performApiSetup();
   if (_result.outcome == DeviceSetupOutcome::Success) {
-    downloadSetupImage();
+    if (_result.imageUrl.isEmpty()) {
+      _result.friendlyId = _persistence.readString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
+      _result.showSetupScreen = true;
+    } else {
+      downloadSetupImage();
+    }
   }
   return _result;
 }


### PR DESCRIPTION
## Problem

When `/api/setup` succeeds but the response contains no setup image URL, the device still tried to download an empty URL instead of showing the setup screen.

## Change

In `DeviceSetup::perform()`, when setup succeeds with an empty `imageUrl`, skip the download and show the `FRIENDLY_ID` setup screen using the stored friendly id.

## Testing

- Builds clean for `seeed_reTerminal_E1001`.
