### PR TITLE
Fixes high sleep current of BWYR panels

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -480,7 +480,7 @@ void display_wipe(void)
     for (int i=0; i<refreshCount; i++) {
         bbep.refresh(REFRESH_FULL); // 2 to 3 minutes of Black/White clearing of the display
     }
-    bbep.sleep(LIGHT_SLEEP);
+    bbep.sleep((bbep.capabilities() & BBEP_4COLOR) ? DEEP_SLEEP : LIGHT_SLEEP);
 #else
     bbep.setMode(BB_MODE_1BPP);
     bbep.fillScreen(BBEP_WHITE);
@@ -2712,7 +2712,7 @@ void display_sleep(void)
 {
     Log_info("Goto Sleep...");
 #ifdef BB_EPAPER
-    bbep.sleep(LIGHT_SLEEP);
+    bbep.sleep((bbep.capabilities() & BBEP_4COLOR) ? DEEP_SLEEP : LIGHT_SLEEP);
 #else
     bbep.einkPower(0);
     bbep.deInit();


### PR DESCRIPTION
The BWYR panels exhibit high sleep current (600uA) when light sleep is requested; the current should be around 10uA. This changes the sleep mode to deep sleep which does achieve the very low sleep current.
