### PR TITLE
Fix time sync fail due to timeout

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1184,13 +1184,10 @@ void bl_init(void)
 #endif
 
   // clock synchronization
-  if (systemClock().setTimeFromNTP())
-  {
+  if (systemClock().setTimeFromNTP()) {
     time_since_sleep = preferences.getUInt(PREFERENCES_LAST_SLEEP_TIME, 0);
-    time_since_sleep = time_since_sleep ? systemClock().getTime() - time_since_sleep : 0; // may be can be used even if no sync
-  }
-  else
-  {
+    time_since_sleep = time_since_sleep ? systemClock().getTime() - time_since_sleep : 0; // maybe can be used even if no sync
+  } else {
     time_since_sleep = 0;
     Log.info("%s [%d]: Time wasn't synced.\r\n", __FILE__, __LINE__);
   }

--- a/src/misc/clock/clock.cpp
+++ b/src/misc/clock/clock.cpp
@@ -71,7 +71,7 @@ bool Clock::sync(Preferences &prefs, const String &ntpServer) {
 
   if (getLocalTime(&timeinfo)) {
     sync_status = true;
-    Log.info("%s [%d]: Time sync succeed in %d ms\r\n", __FILE__, __LINE__, (int)(millis() - start_ms));
+    Log.info("%s [%d]: Time sync succeeded in %d ms\r\n", __FILE__, __LINE__, (int)(millis() - start_ms));
     prefs.putUInt("last_sync", getTime()); // save epoch time of last sync
   } else {
     Log.info("%s [%d]: Time sync failed...\r\n", __FILE__, __LINE__);

--- a/src/misc/clock/clock.cpp
+++ b/src/misc/clock/clock.cpp
@@ -4,6 +4,9 @@
 
 #include "esp_sntp.h"
 
+#define CLOCK_SNTP_TIMEOUT_MS 10000
+#define CLOCK_SNTP_POLL_MS    50
+
 uint32_t Clock::getTime() {
   time_t now;
   struct tm timeinfo;
@@ -42,7 +45,8 @@ bool Clock::setTimeFromNTP() {
 
 bool Clock::sync(Preferences &prefs, const String &ntpServer) {
   bool sync_status = false;
-  struct tm timeinfo;
+  struct tm timeinfo = {};
+  esp_sntp_set_sync_status(SNTP_SYNC_STATUS_RESET);
 
   configTime(0, 0, ntpServer.c_str(), "pool.ntp.org");
 
@@ -55,15 +59,22 @@ bool Clock::sync(Preferences &prefs, const String &ntpServer) {
     }
   }
 
-  Log.info("%s [%d]: Time synchronization...\r\n", __FILE__, __LINE__);
+  Log.info("%s [%d]: Time sync started\r\n", __FILE__, __LINE__);
 
-  // Wait for time to be set
+  const uint32_t start_ms = millis();
+  while (millis() - start_ms < CLOCK_SNTP_TIMEOUT_MS) {
+    if (esp_sntp_get_sync_status() == SNTP_SYNC_STATUS_COMPLETED) {
+      break;
+    }
+    delay(CLOCK_SNTP_POLL_MS);
+  }
+
   if (getLocalTime(&timeinfo)) {
     sync_status = true;
-    Log.info("%s [%d]: Time synchronization succeed!\r\n", __FILE__, __LINE__);
+    Log.info("%s [%d]: Time sync succeed in %d ms\r\n", __FILE__, __LINE__, (int)(millis() - start_ms));
     prefs.putUInt("last_sync", getTime()); // save epoch time of last sync
   } else {
-    Log.info("%s [%d]: Time synchronization failed...\r\n", __FILE__, __LINE__);
+    Log.info("%s [%d]: Time sync failed...\r\n", __FILE__, __LINE__);
   }
 
   Log.info("%s [%d]: Current time - %s\r\n", __FILE__, __LINE__, asctime(&timeinfo));


### PR DESCRIPTION
**Problem:**
I noticed that my TRMNL X has lost sync of time, it was ahead of the time by 10 minutes. To investigate, I tried to bypass the 24 hrs check and the clock didn't sync even then. I found that log consistently succeeded in 5000ms (I added some diagnostics logs)

**before**
logs with diagnostics:
```
I: src/misc/clock/clock.cpp [78]: Time synchronization...
I: src/misc/clock/clock.cpp [105]: Time synchronization succeed after 5000 ms
```
logs from main, Current time is wrong and is off by 30 mins.
```
I: src/misc/clock/clock.cpp [58]: Time synchronization...
I: src/misc/clock/clock.cpp [63]: Time synchronization succeed!
I: src/misc/clock/clock.cpp [69]: Current time - Mon Aug 31 14:48:13 2026
```

I found that by default [getLocalTime](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/Arduino.h#L273) has a timeout of 5s. hence it silently succeeds and the device never attempts to sync the time for next 24 hrs.

**Solution:**
This PR sets `esp_sntp_set_sync_status` to `SNTP_SYNC_STATUS_RESET` and then polls the status until it changes to `SNTP_SYNC_STATUS_COMPLETED` for 10s.

after logs:
```
I: src/misc/clock/clock.cpp [38]: Using NTP: time.google.com, fallback: pool.ntp.org
I: src/misc/clock/clock.cpp [58]: SNTP server[0]: time.google.com
I: src/misc/clock/clock.cpp [62]: Time sync started
I: src/misc/clock/clock.cpp [74]: Time sync succeed in 2200 ms
I: src/misc/clock/clock.cpp [80]: Current time - Thu Aug 27 13:47:48 2026
```