### PR TITLE
Report USB and charging status on reTerminal E1001/E1003

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -143,6 +143,10 @@
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
 #define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define CHARGER_SY6974               // SY6974B I2C charger PMIC
+#define CHARGER_I2C_BUS   Wire1      // SY6974B sits on I2C1
+#define CHARGER_I2C_SDA   39
+#define CHARGER_I2C_SCL   40
 #elif defined(BOARD_SEEED_RETERMINAL_E1002)
 #define DEVICE_MODEL      "reterminal_e1002"
 #define PIN_INTERRUPT     3 // the green button
@@ -156,6 +160,10 @@
 #define PIN_VBAT_SWITCH   40
 #define VBAT_SWITCH_LEVEL HIGH
 #define DEVICE_MODEL      "reterminal_e1003"
+#define CHARGER_SY6974               // SY6974B I2C charger PMIC
+#define CHARGER_I2C_BUS   Wire       // SY6974B sits on I2C0 (shared with RTC / sensor)
+#define CHARGER_I2C_SDA   19
+#define CHARGER_I2C_SCL   20
 #endif
 
 // DHCP hostname prefix (hyphens instead of spaces).

--- a/include/power.h
+++ b/include/power.h
@@ -39,6 +39,17 @@ private:
   uint8_t _statPin;
 };
 
+/// @brief Reads USB presence and charge state from the SY6974B status register.
+class SY6974Power : public BasePower {
+public:
+  UsbStatus usbStatus() override;
+  ChargingStatus chargingStatus() override;
+
+private:
+  bool readStatus(uint8_t &status);
+  bool busStarted = false;
+};
+
 #ifdef INCLUDE_TCA9535_POWER
 class FASTEPD;
 

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -11,6 +11,8 @@ extern FASTEPD bbep;
 static TCA9535Power powerInstance(bbep, TCA9535_PG_PIN, TCA9535_STAT_PIN);
 #elif defined(INCLUDE_GPIO_POWER)
 static GPIOPower powerInstance(BQ25616_PG_PIN, BQ25616_STAT_PIN);
+#elif defined(CHARGER_SY6974)
+static SY6974Power powerInstance;
 #else
 static BasePower powerInstance;
 #endif

--- a/src/power/sy6974_power.cpp
+++ b/src/power/sy6974_power.cpp
@@ -1,0 +1,51 @@
+#include <Arduino.h>
+#include <Wire.h>
+
+#include <config.h>
+#include <power.h>
+
+#ifdef CHARGER_SY6974
+
+#ifndef CHARGER_I2C_ADDR
+#define CHARGER_I2C_ADDR 0x6B
+#endif
+
+static constexpr uint8_t SY6974_REG_STATUS = 0x08;
+static constexpr uint8_t SY6974_VBUS_STAT_MASK = 0xE0;
+static constexpr uint8_t SY6974_CHRG_STAT_MASK = 0x18;
+static constexpr uint8_t SY6974_CHRG_STAT_SHIFT = 3;
+
+bool SY6974Power::readStatus(uint8_t &status) {
+  if (!busStarted) {
+    CHARGER_I2C_BUS.begin(CHARGER_I2C_SDA, CHARGER_I2C_SCL);
+    CHARGER_I2C_BUS.setClock(100000);
+    busStarted = true;
+  }
+
+  CHARGER_I2C_BUS.beginTransmission(CHARGER_I2C_ADDR);
+  CHARGER_I2C_BUS.write(SY6974_REG_STATUS);
+  if (CHARGER_I2C_BUS.endTransmission(false) != 0) return false;
+  if (CHARGER_I2C_BUS.requestFrom((int) CHARGER_I2C_ADDR, 1) != 1) return false;
+
+  status = CHARGER_I2C_BUS.read();
+  return true;
+}
+
+UsbStatus SY6974Power::usbStatus() {
+  uint8_t status;
+  if (!readStatus(status)) return UsbStatus::UNKNOWN;
+
+  // VBUS_STAT is zero only when no input source is connected. PG_STAT cannot
+  // be used because this chip keeps it asserted while running from battery.
+  return (status & SY6974_VBUS_STAT_MASK) ? UsbStatus::CONNECTED : UsbStatus::DISCONNECTED;
+}
+
+ChargingStatus SY6974Power::chargingStatus() {
+  uint8_t status;
+  if (!readStatus(status)) return ChargingStatus::UNKNOWN;
+
+  uint8_t chargeStatus = (status & SY6974_CHRG_STAT_MASK) >> SY6974_CHRG_STAT_SHIFT;
+  return (chargeStatus == 1 || chargeStatus == 2) ? ChargingStatus::CHARGING : ChargingStatus::NOT_CHARGING;
+}
+
+#endif // CHARGER_SY6974

--- a/src/power/sy6974_power.cpp
+++ b/src/power/sy6974_power.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
 #include <Wire.h>
-
 #include <config.h>
 #include <power.h>
 
@@ -25,7 +24,7 @@ bool SY6974Power::readStatus(uint8_t &status) {
   CHARGER_I2C_BUS.beginTransmission(CHARGER_I2C_ADDR);
   CHARGER_I2C_BUS.write(SY6974_REG_STATUS);
   if (CHARGER_I2C_BUS.endTransmission(false) != 0) return false;
-  if (CHARGER_I2C_BUS.requestFrom((int) CHARGER_I2C_ADDR, 1) != 1) return false;
+  if (CHARGER_I2C_BUS.requestFrom((int)CHARGER_I2C_ADDR, 1) != 1) return false;
 
   status = CHARGER_I2C_BUS.read();
   return true;


### PR DESCRIPTION
## Summary

Report USB connection and battery charging status for reTerminal E1001 and E1003 through the existing API headers.

## Testing

- Built `seeed_reTerminal_E1001`
- Built `TRMNL_X_E1003`