### PR TITLE
Wake on all three E1001 buttons and report which one was pressed

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -137,12 +137,16 @@
 #define PIN_VBAT_SWITCH   6 // load switch enable pin for battery voltage measurement
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #elif defined(BOARD_SEEED_RETERMINAL_E1001)
-#define DEVICE_MODEL      "reterminal_e1001"
-#define PIN_INTERRUPT     3 // the green button
-#define PIN_VBAT_SWITCH   21 // load switch enable pin for battery voltage measurement
-#define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
-#define PIN_BUZZER        45          // passive buzzer (MLT-8530) via NPN transistor
-#define BUZZER_FREQ       2700       // resonant frequency of MLT-8530 in Hz
+#define DEVICE_MODEL        "reterminal_e1001"
+#define PIN_INTERRUPT       3 // the green button
+#define MULTI_BUTTON_WAKEUP // all three buttons wake; Update-Source names which
+#define PIN_BUTTON_A        4 // reported as button_a, no external pull-up
+#define PIN_BUTTON_B        5 // reported as button_b, no external pull-up
+#define BUTTON_WAKEUP_MASK  ((1ULL << PIN_INTERRUPT) | (1ULL << PIN_BUTTON_A) | (1ULL << PIN_BUTTON_B))
+#define PIN_VBAT_SWITCH     21 // load switch enable pin for battery voltage measurement
+#define VBAT_SWITCH_LEVEL   HIGH // load switch enable pin active level
+#define PIN_BUZZER          45          // passive buzzer (MLT-8530) via NPN transistor
+#define BUZZER_FREQ         2700       // resonant frequency of MLT-8530 in Hz
 #elif defined(BOARD_SEEED_RETERMINAL_E1002)
 #define DEVICE_MODEL      "reterminal_e1002"
 #define PIN_INTERRUPT     3 // the green button

--- a/lib/trmnl/include/button_wakeup.h
+++ b/lib/trmnl/include/button_wakeup.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdint.h>
+
+// Maps an ext1 wake mask to the value reported in the Update-Source header:
+// mainPin reports "button", buttonAPin "button_a", buttonBPin "button_b".
+// mainPin takes precedence when the mask names more than one. Returns nullptr
+// when it names none of the three. The pins are arguments rather than board
+// macros so the mapping can be tested natively.
+inline const char *updateSourceForWakeBits(uint64_t wakeBits, int mainPin, int buttonAPin, int buttonBPin) {
+  if (wakeBits & (1ULL << mainPin)) return "button";
+  if (wakeBits & (1ULL << buttonAPin)) return "button_a";
+  if (wakeBits & (1ULL << buttonBPin)) return "button_b";
+  return nullptr;
+}

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -56,6 +56,25 @@
 #include "messages.h"
 #include "displayed_image.h"
 #include <globals.h>
+#ifdef MULTI_BUTTON_WAKEUP
+#include "driver/rtc_io.h"
+#include <button_wakeup.h>
+static uint64_t ext1_wake_bits = 0; // which ext1 pin(s) woke us
+
+// Wake on any of the device's buttons. The extra buttons rely on internal
+// pull-ups, which must be held through deep sleep via the RTC domain.
+static void multi_button_arm_wakeup(void)
+{
+  for (gpio_num_t p : {(gpio_num_t)PIN_INTERRUPT, (gpio_num_t)PIN_BUTTON_A, (gpio_num_t)PIN_BUTTON_B})
+  {
+    rtc_gpio_init(p);
+    rtc_gpio_set_direction(p, RTC_GPIO_MODE_INPUT_ONLY);
+    rtc_gpio_pullup_en(p);
+    rtc_gpio_pulldown_dis(p);
+  }
+  esp_sleep_enable_ext1_wakeup(BUTTON_WAKEUP_MASK, ESP_EXT1_WAKEUP_ANY_LOW);
+}
+#endif
 const char *szHTTPErrors[] = {
     "HTTPS_NO_ERR",
     "HTTPS_RESET",
@@ -781,6 +800,17 @@ void bl_init(void)
                       wakeup_reason == ESP_SLEEP_WAKEUP_EXT1);
   Log.info("%s [%d]: Wake reason: %d\r\n", __FILE__, __LINE__, (int)wakeup_reason);
 
+  bool skip_button_read = false;
+#ifdef MULTI_BUTTON_WAKEUP
+  if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT1)
+  {
+    ext1_wake_bits = esp_sleep_get_ext1_wakeup_status();
+    Log_info("ext1 wake bits=0x%llx", (unsigned long long)ext1_wake_bits);
+    // An extra-button wake is a plain press: the classification below reads
+    // only PIN_INTERRUPT and would idle through its double-click window.
+    skip_button_read = ext1_wake_bits != 0 && (ext1_wake_bits & (1ULL << PIN_INTERRUPT)) == 0;
+  }
+#endif
   Log_info("preferences start");
   bool res = preferences.begin("data", false);
   if (res)
@@ -795,7 +825,7 @@ void bl_init(void)
   Log_info("preferences end");
   #ifndef BOARD_TRMNL_X
   bool double_click = false;
-  if (gpio_wakeup)
+  if (gpio_wakeup && !skip_button_read)
   {
     Log_info("GPIO wakeup detected (%d)", wakeup_reason);
     auto button = read_button_presses();
@@ -1422,6 +1452,17 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   {
     inputs.updateSource = "unknown";
   }
+#ifdef MULTI_BUTTON_WAKEUP
+  // Name the button that woke us in Update-Source. PIN_INTERRUPT reports
+  // "button"; the other two report "button_a" and "button_b".
+  if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT1 && ext1_wake_bits != 0)
+  {
+    const char *button_source =
+        updateSourceForWakeBits(ext1_wake_bits, PIN_INTERRUPT, PIN_BUTTON_A, PIN_BUTTON_B);
+    if (button_source != nullptr)
+      inputs.updateSource = button_source;
+  }
+#endif
 
   if (preferences.isKey(PREFERENCES_API_KEY))
   {
@@ -2651,7 +2692,11 @@ void goToSleep(void)
   pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#ifdef MULTI_BUTTON_WAKEUP
+  multi_button_arm_wakeup();
+#else
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#endif
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
 #endif
@@ -2686,7 +2731,11 @@ static void goToSleepButtonOnly(void)
 #elif defined( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 )
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif CONFIG_IDF_TARGET_ESP32S3
+#ifdef MULTI_BUTTON_WAKEUP
+  multi_button_arm_wakeup();
+#else
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#endif
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
 #endif

--- a/src/pins.cpp
+++ b/src/pins.cpp
@@ -6,7 +6,11 @@ void pins_init(void) {
   gpio_config_t io_conf = {};
   io_conf.intr_type = GPIO_INTR_DISABLE;
   io_conf.mode = GPIO_MODE_INPUT;
+#ifdef MULTI_BUTTON_WAKEUP
+  io_conf.pin_bit_mask = BUTTON_WAKEUP_MASK;
+#else
   io_conf.pin_bit_mask = (1ULL << PIN_INTERRUPT);
+#endif
   io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
   io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
   gpio_config(&io_conf);

--- a/test/test_button_wakeup/button_wakeup.test.cpp
+++ b/test/test_button_wakeup/button_wakeup.test.cpp
@@ -1,0 +1,58 @@
+#include <button_wakeup.h>
+#include <unity.h>
+
+// Pin assignment of the reTerminal E1001. The helper takes the pins as
+// arguments, so these are just representative values.
+static const int PIN_MAIN = 3;
+static const int BUTTON_A = 4;
+static const int BUTTON_B = 5;
+
+static const char *sourceFor(uint64_t bits) { return updateSourceForWakeBits(bits, PIN_MAIN, BUTTON_A, BUTTON_B); }
+
+// --- one button at a time --------------------------------------------------
+
+void test_main_pin_reports_button(void) { TEST_ASSERT_EQUAL_STRING("button", sourceFor(1ULL << PIN_MAIN)); }
+
+void test_gpio4_reports_button_a(void) { TEST_ASSERT_EQUAL_STRING("button_a", sourceFor(1ULL << BUTTON_A)); }
+
+void test_gpio5_reports_button_b(void) { TEST_ASSERT_EQUAL_STRING("button_b", sourceFor(1ULL << BUTTON_B)); }
+
+// --- masks that name no button, or more than one ---------------------------
+
+void test_empty_mask_is_unmapped(void) { TEST_ASSERT_NULL(sourceFor(0)); }
+
+void test_unrelated_pin_is_unmapped(void) { TEST_ASSERT_NULL(sourceFor(1ULL << 21)); }
+
+void test_main_pin_wins_when_several_are_held(void) {
+  // PIN_MAIN takes precedence over the other two.
+  TEST_ASSERT_EQUAL_STRING("button", sourceFor((1ULL << PIN_MAIN) | (1ULL << BUTTON_A) | (1ULL << BUTTON_B)));
+}
+
+void test_extra_buttons_do_not_mask_each_other(void) {
+  TEST_ASSERT_EQUAL_STRING("button_a", sourceFor((1ULL << BUTTON_A) | (1ULL << BUTTON_B)));
+}
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+void process() {
+  UNITY_BEGIN();
+  RUN_TEST(test_main_pin_reports_button);
+  RUN_TEST(test_gpio4_reports_button_a);
+  RUN_TEST(test_gpio5_reports_button_b);
+  RUN_TEST(test_empty_mask_is_unmapped);
+  RUN_TEST(test_unrelated_pin_is_unmapped);
+  RUN_TEST(test_main_pin_wins_when_several_are_held);
+  RUN_TEST(test_extra_buttons_do_not_mask_each_other);
+  UNITY_END();
+}
+
+int main(int argc, char **argv) {
+  process();
+  return 0;
+}


### PR DESCRIPTION
E1001 has GPIO3, GPIO4 and GPIO5. The firmware enables ext0 wakeup on GPIO3 only. The other two don't do anything. This PR enables ext1 wakeup across all three. It keeps their internal pull-ups on during deep sleep, and reports the source in `Update-Source`. GPIO3 still reports `button`, GPIO4 reports `button_a`, GPIO5 reports `button_b`.

#446 left all three buttons acting identically, and the author closed it. I think reporting *which* button woke the device is important.
