### PR TITLE
X partial updates

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1482,11 +1482,14 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
 void load_prev_image(void)
 {
   uint8_t *buffer;
-  size_t content_size = 0;
-  if (content_size > 0) {
+  int file_size = 0;
+
+  buffer = display_read_file(DisplayedImage::get(), &file_size);
+  if (file_size > 0) {
     // Decode it into the previous buffer
     Log.info("%s [%d]: Decoding previous image (%s) into the EPD 'old' buffer\r\n", __FILE__, __LINE__, DisplayedImage::get());
-    png_to_epd(buffer, content_size, true);
+    png_to_epd(buffer, file_size, true);
+    free(buffer);
   }
 } /* load_prev_image() */
 
@@ -1562,7 +1565,10 @@ static https_request_err_e downloadAndShow()
       char szTemp[36];
 #if PARALLEL_EPD && !defined(BOARD_SEEED_RETERMINAL_E1003)
       if (DisplayedImage::exists()) {
+        Log_info("%s [%d]: Previous image exists; loading it to do a partial update\n", __FILE__, __LINE__);
         load_prev_image(); // decode the older image into the previous buffer of FastEPD
+      } else {
+        Log_info("%s [%d]: Previous image does not exist\n", __FILE__, __LINE__);
       }
 #endif
       filesystem_fix_filename(apiDisplayResult.response.filename.c_str(), szTemp);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -644,6 +644,7 @@ void display_draw_touchbar_indicator(touchbar_side_t side, bool filled)
         bbep.fillRect(rx - border, ry - border, rect_w + (2*border), rect_h + (2*border), border_color);
         bbep.fillRect(rx, ry, rect_w, rect_h, fill_color);
         bbep.partialUpdate(false);
+        bbep.setPreviousMode(BB_MODE_NONE); // we can't do partial updates since we don't have the contents
 } /* display_draw_touchbar_indicator() */
 #endif
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1732,6 +1732,7 @@ PNG *png = new PNG();
                 break;
             }
             Log_info("%s [%d]: FastEPD graphics mode set to: %d\n", __FILE__, __LINE__, bbep.getMode());
+            Log_info("%s [%d]: Decoding %s PNG image\n", __FILE__, __LINE__, (bPrevious) ? "previous" : "current");
             png->decode((void *)bPrevious, 0);
             png->close();
 #endif
@@ -1913,19 +1914,24 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait, bool b
     int rc = bbep.setCustomMatrix(u8_graytable, sizeof(u8_graytable));
     Log_info("%s [%d]: setCustomMatrix returned %d\r\n", __FILE__, __LINE__, rc);
 
- //   if (bbep.getPreviousMode() != BB_MODE_NONE && (bbep.getMode() == BB_MODE_1BPP || bbep.getMode() == BB_MODE_2BPP)) {
- //       Log_info("%s [%d]: Using partial update since we have a copy of the previous image\n", __FILE__, __LINE__);
- //       bbep.setPasses(6,6);
- //       bbep.partialUpdate(false); // we have a previous image to diff against; use a non-flickering update
- //   } else {
+    if (bbep.getPreviousMode() != BB_MODE_NONE && (bbep.getMode() == BB_MODE_1BPP || bbep.getMode() == BB_MODE_2BPP)) {
+        Log_info("%s [%d]: Using partial update since we have a copy of the previous image\n", __FILE__, __LINE__);
+        bbep.setPasses(6,6);
+        bbep.partialUpdate(false); // we have a previous image to diff against; use a non-flickering update
+    } else {
         // bWait=false means loading screen: skip clearing passes so it appears
         // faster. Ghosting from the previous image is acceptable since the
         // real content refresh (bWait=true) immediately follows.
+        Log_info("%s [%d]: Doing a full update since we don't have a copy of the previous image\n", __FILE__, __LINE__);
         int iClearMode = bSkipClear ? CLEAR_NONE
                                    : ((iUpdateCount & 7) == 0 || (iTempProfile > 0)) ? CLEAR_SLOW : CLEAR_FAST;
         Log_info("fullUpdate clear mode = %d\n", iClearMode);
         bbep.fullUpdate(iClearMode, false);
- //   }
+        if (bSkipClear) {
+            Log_info("%s [%d]: We can't do a partial update after this faded loading screen\n", __FILE__, __LINE__);
+            bbep.setPreviousMode(BB_MODE_NONE);
+        }
+    }
  }
 #endif
     iUpdateCount++;

--- a/src/displayed_image.cpp
+++ b/src/displayed_image.cpp
@@ -1,22 +1,28 @@
 #include "displayed_image.h"
 
 #include <string.h>
+#include <trmnl_log.h>
 
 #include "esp_attr.h"
 
+// SPIFFS path of the image currently on the display
+RTC_DATA_ATTR static char szPrevFile[36] = {0}; // must be OUTSIDE of namespace
+
 namespace DisplayedImage {
-    // SPIFFS path of the image currently on the display
-  RTC_DATA_ATTR static char szPrevFile[36] = {0};
 
     // filename must already be a 32-byte fixed SPIFFS path (see Storage::fix_file_name)
   void remember(const char *filename) {
     strncpy(szPrevFile, filename, sizeof(szPrevFile) - 1);
     szPrevFile[sizeof(szPrevFile) - 1] = '\0';
+    Log_info("%s [%d]: Remembering previous file: %s\n", __FILE__, __LINE__, szPrevFile);
   }
 
   void clear() { memset(szPrevFile, 0, sizeof(szPrevFile)); }
 
-  bool exists() { return szPrevFile[0] != '\0'; }
+  bool exists() {
+      Log_info("%s [%d]: Checking if szPrevFile[] exists: %s\n", __FILE__, __LINE__, szPrevFile);
+      return szPrevFile[0] != '\0';
+  }
 
   bool matches(const char *filename) { return strcmp(szPrevFile, filename) == 0; }
 


### PR DESCRIPTION
This PR adds non-flickering updates to the TRMNL X. In order for it not to do a black/white clearing of the screen when a new image is drawn, the previous and current images must be 1-bit per pixel. Any other combination will require a full clearing of the display before the new image is displayed. There is currently some ghosting visible and I will work on trying to reduce it.
