### PR TITLE
Continue retry WiFi  after max attempts reached.

### DIFF
--- a/lib/trmnl/include/refresh_interval.h
+++ b/lib/trmnl/include/refresh_interval.h
@@ -32,11 +32,12 @@ public:
 
   // Retry ladders; attempt is 1-based.
   uint32_t applyApiRetry(uint8_t attempt);  // 15 / 30 / 60, then DEFAULT_SECONDS
-  uint32_t applyWifiRetry(uint8_t attempt); // 60 / 180, then 300
+  uint32_t applyWifiRetry(uint8_t attempt); // 60 / 120 / 180, then 300
   uint32_t applyDefault();                  // fixed fallback, e.g. /api/setup 404
 
 private:
   static uint32_t fastPollSeconds(uint32_t streak);
+  static uint32_t wifiRetrySeconds(uint8_t attempt);
   bool writeIfChanged(uint32_t value);
 
   Persistence &persistence;

--- a/lib/trmnl/src/refresh_interval.cpp
+++ b/lib/trmnl/src/refresh_interval.cpp
@@ -45,18 +45,7 @@ uint32_t RefreshInterval::applyApiRetry(uint8_t attempt) {
 }
 
 uint32_t RefreshInterval::applyWifiRetry(uint8_t attempt) {
-  uint32_t sleep;
-  switch (attempt) {
-  case 1:
-    sleep = 60;
-    break;
-  case 2:
-    sleep = 180;
-    break;
-  default:
-    sleep = 300;
-    break;
-  }
+  uint32_t sleep = wifiRetrySeconds(attempt);
   writeIfChanged(sleep);
   return sleep;
 }
@@ -71,6 +60,13 @@ uint32_t RefreshInterval::fastPollSeconds(uint32_t streak) {
   if (streak <= 60) return 60;  // 1 min
   if (streak <= 70) return 900; // 15 min
   return 3600;                  // 1 hour
+}
+
+uint32_t RefreshInterval::wifiRetrySeconds(uint8_t attempt) {
+  if (attempt <= 2) return 60;    // 1 min
+  if (attempt <= 5) return 120;   // 2 min
+  if (attempt <= 10) return 180;  // 3 min
+  return 300;                     // 5 min
 }
 
 bool RefreshInterval::writeIfChanged(uint32_t value) {

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1112,9 +1112,12 @@ void bl_init(void)
     }
     else
     {
-      if (current_msg != WIFI_FAILED)
-      {
-        showMessageWithLogo(WIFI_FAILED);
+      if (current_msg != WIFI_FAILED) {
+        int attempts = preferences.getInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
+        if (attempts < 10)
+          showMessageWithLogo(WIFI_FAILED);
+        else
+          showMessageWithLogo(WIFI_RETRY_LIMIT);
         current_msg = WIFI_FAILED;
       }
 
@@ -2954,30 +2957,14 @@ static uint8_t *storedLogoOrDefault(int iType)
 
 static void wifiErrorDeepSleep()
 {
-  if (!preferences.isKey(PREFERENCES_CONNECT_WIFI_RETRY_COUNT))
-  {
+  if (!preferences.isKey(PREFERENCES_CONNECT_WIFI_RETRY_COUNT)) {
     preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
   }
 
   uint8_t retry_count = preferences.getInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT);
-
   Log_info("WIFI connection failed! Retry count: %d \n", retry_count);
 
-  switch (retry_count)
-  {
-  case 1:
-  case 2:
-  case 3:
-    refreshInterval.applyWifiRetry(retry_count);
-    break;
-
-  default:
-    preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
-    showMessageWithLogo(WIFI_RETRY_LIMIT);
-    display_sleep();
-    goToSleepButtonOnly();
-    return;
-  }
+  refreshInterval.applyWifiRetry(retry_count);
   retry_count++;
   preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, retry_count);
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2443,7 +2443,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     break;
     case WIFI_RETRY_LIMIT:
     {
-        const char string1[] = "Maximum WiFi retries reached.";
+        const char string1[] = "Maximum WiFi retries reached. Retrying in 5m";
         bbep.getStringBox(string1, &rect);
 #ifdef __BB_EPAPER__
         bbep.setCursor((bbep.width() - rect.w) / 2, 340);

--- a/test/test_refresh_interval/refresh_interval.test.cpp
+++ b/test/test_refresh_interval/refresh_interval.test.cpp
@@ -115,8 +115,12 @@ void test_wifi_retry_ladder(void) {
   MemoryPersistence persistence;
   RefreshInterval refreshInterval(persistence);
   TEST_ASSERT_EQUAL_UINT32(60, refreshInterval.applyWifiRetry(1));
-  TEST_ASSERT_EQUAL_UINT32(180, refreshInterval.applyWifiRetry(2));
-  TEST_ASSERT_EQUAL_UINT32(300, refreshInterval.applyWifiRetry(3));
+  TEST_ASSERT_EQUAL_UINT32(60, refreshInterval.applyWifiRetry(2));
+  TEST_ASSERT_EQUAL_UINT32(120, refreshInterval.applyWifiRetry(3));
+  TEST_ASSERT_EQUAL_UINT32(120, refreshInterval.applyWifiRetry(5));
+  TEST_ASSERT_EQUAL_UINT32(180, refreshInterval.applyWifiRetry(6));
+  TEST_ASSERT_EQUAL_UINT32(180, refreshInterval.applyWifiRetry(9));
+  TEST_ASSERT_EQUAL_UINT32(300, refreshInterval.applyWifiRetry(10));
   TEST_ASSERT_EQUAL_UINT32(300, refreshInterval.seconds());
 }
 


### PR DESCRIPTION
**Problem:**
This FW [commit](https://github.com/usetrmnl/trmnl-firmware/commit/8f60010a8c68fe92928e4d4964273de60f8796cf) (released in 1.8.3) has introduced a change where WiFi connection failure after 3 attempts lead to recovery only using `goToSleepButtonOnly();`. 

This change has lead to a lot of device remaining in "Maximum WiFi retries reached." error state forever, eventually the only way to recover from this state is a manual action (button press, tap the touch bar). This change is especially bad for business owning a fleet of 50+ TRMNL devices where oftentimes manual action is unrealistic. 

**Solution**
Revert to pre 1.8.3 solution where the device keeps retrying at regular interval. I've made a small change in the WiFi retry logic where it tries to recover from a patchy WiFi quickly in the first few tries. After that it'd constantly retry every 5 minutes.

 | attempt | seconds |                                                                                                                                                                                                              
  |---------|---------|                                                                                                                                                                                                              
  | 1-2     | 60      |                                                                                                                                                                                                              
  | 3-5     | 120     |                                                                                                                                                                                                              
  | 6-9     | 180     |                                                                                                                                                                                                              
  | 10+     | 300     |

**Steps to Reproduce**
I was able to reproduce this issue by blocking my TRMNL from my WiFi network. TRMNL would stay on "Maximum WiFi retries reached." after 3 attempts forever and doesn't self-heal.

After this change TRMNL keeps attempting WiFi reconnection as per the table above. I've tried to unblock my TRMNL after 15th attempt and the device did self heal and reset the counter. I also tried to block my TRMNL after a couple of attempts and the device started the WiFi connection counter as expected.

**Tests:**
- [X] TRMNL OG
- [ ] TRMNL X
- [ ] TRMNL BWRY
