### PR TITLE
Adds support for the Crowpanel 4.2 inch B/W e-paper device

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -331,12 +331,12 @@ build_flags =
     -D BOARD_TRMNL_X_LILYGO
 	-D DEVICE_MODEL=\"lilygo_t5pro\"
 	-D PARALLEL_EPD
-    -D ARDUINO_USB_MODE=1
-    -D ARDUINO_USB_CDC_ON_BOOT=1
-    -D CORE_DEBUG_LEVEL=4
+;    -D ARDUINO_USB_MODE=1
+;    -D ARDUINO_USB_CDC_ON_BOOT=1
+;    -D CORE_DEBUG_LEVEL=4
     -D PNG_MAX_BUFFERED_PIXELS=7696
-    -D WAIT_FOR_SERIAL=1
-    -D DEV_FIRMWARE=1
+;    -D WAIT_FOR_SERIAL=1
+;    -D DEV_FIRMWARE=1
     -D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 
 board_build.embed_txtfiles =
@@ -453,6 +453,7 @@ build_flags =
     -D WAIT_FOR_SERIAL=1
     -D DEV_FIRMWARE=1
     -D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+	-D DO_NOT_LIGHT_SLEEP=1
 
 board_build.embed_txtfiles =
     managed_components/espressif__esp_insights/server_certs/https_server.crt
@@ -961,13 +962,23 @@ board_build.extra_flags =
 	-D ARDUINO_EVENT_RUNNING_CORE=1
 build_flags =
 	${env:esp32_base.build_flags}
-	-D ARDUINO_USB_MODE=0
-	-D ARDUINO_USB_CDC_ON_BOOT=0
+;    -D ARDUINO_USB_MODE=0
+;    -D ARDUINO_USB_CDC_ON_BOOT=0
 	-D PNG_MAX_BUFFERED_PIXELS=6432
 	-D DEVICE_MODEL=\"crowpanel42\"
-    -D WAIT_FOR_SERIAL=1
-    -D DO_NOT_LIGHT_SLEEP=1
-    -D DEV_FIRMWARE=1
+;    -D WAIT_FOR_SERIAL=1
+;    -D DO_NOT_LIGHT_SLEEP=1
+;    -D DEV_FIRMWARE=1
+
+lib_deps =
+	bblanchon/ArduinoJson@7.4.2
+	bitbank2/PNGdec@^1.1.6
+	bitbank2/JPEGDEC@^1.8.4
+	bitbank2/bb_scd41@1.3.2
+	https://github.com/bitbank2/bb_temperature.git#c660acbdabe25793b560e2546b97440bf7c42016
+	ESP32Async/ESPAsyncWebServer@3.7.7
+    https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+    https://github.com/bitbank2/bb_epaper.git#81f21e988c6d6ce5f0bd55ee6bffba1d57a3c4a6
 
 [env:m5_paper_mono]
 board = esp32-s3-devkitc-1

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -525,7 +525,11 @@ void display_wipe(void)
     int refreshCount = 60;
 #endif
 
-    bbep.setPanelType(dpList[pDevice->panel_set][iTempProfile].OneBit);
+    if (pDevice->epd_mosi_pin == pDevice->epd_sck_pin) { // predefined device
+        bbep.begin(dpList[pDevice->panel_set][0].OneBit);
+    } else {
+        bbep.setPanelType(dpList[pDevice->panel_set][iTempProfile].OneBit);
+    }
     bbep.fillScreen(BBEP_WHITE);
     for (int i=0; i<refreshCount; i++) {
         bbep.refresh(REFRESH_FULL); // 2 to 3 minutes of Black/White clearing of the display
@@ -1671,7 +1675,11 @@ PNG *png = new PNG();
             bbep.setAddrWindow(0, 0, bbep.width(), bbep.height());
             if (png->getBpp() == 1 || (png->getBpp() == 2 && png_count_colors(png, pPNG, iDataSize) == 2)) { // 1-bit image (single plane)
                 png->close(); // use a different PNGDraw callback for color matching
-                bbep.setPanelType(dpList[pDevice->panel_set][iTempProfile].OneBit);
+                if (pDevice->epd_mosi_pin == pDevice->epd_sck_pin) { // predefined device
+                    bbep.begin(dpList[pDevice->panel_set][0].OneBit);
+                } else {
+                    bbep.setPanelType(dpList[pDevice->panel_set][iTempProfile].OneBit);
+                }
                 rc = REFRESH_PARTIAL; // the new image is 1bpp - try a partial update
                 bbep.startWrite(PLANE_0); // start writing image data to plane 0
                 png->openRAM((uint8_t *)pPNG, iDataSize, png_draw);
@@ -1988,7 +1996,9 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
+    const int iFontHeight = 12;
 #else
+    const int iFontHeight = 24;
     bbep.setMode(BB_MODE_1BPP); // message screens are 1-bit
 #endif
     if (image_buffer && *(uint16_t *)image_buffer == BB_BITMAP_MARKER)
@@ -2119,7 +2129,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     {
         const char string1[] = "Connect to TRMNL WiFi";
         bbep.getStringBox(string1, &rect);
-        bbep.setCursor((bbep.width() - rect.w)/2, 430);
+        bbep.setCursor((bbep.width() - rect.w)/2, height-(iFontHeight*2));
         bbep.println(string1);
         const char string2[] = "on your phone or computer";
         bbep.getStringBox(string2, &rect);
@@ -2132,7 +2142,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
         String string0 = "TRMNL firmware ";
         string0 += Messages::firmware_version();
 #ifdef __BB_EPAPER__
-        bbep.setCursor(40, 48); // place in upper left corner
+        bbep.setCursor(40, iFontHeight*2); // place in upper left corner
 #else
         bbep.setCursor(80, 104); // place in upper left corner
 #endif
@@ -2618,8 +2628,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
+    const int iFontHeight = 12;
     Log_info("Free heap after bbep.allocBuffer() - %" PRIu32, ESP.getMaxAllocHeap());
 #else
+    const int iFontHeight = 24;
     bbep.setMode(BB_MODE_1BPP); // message screens are 1-bit
 #endif
 
@@ -2703,17 +2715,20 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
 
         String string1 = "TRMNL firmware ";
         string1 += fw_version;
-        bbep.setCursor(40, 48); // place in upper left corner
+        bbep.setCursor(40, iFontHeight*2); // place in upper left corner
         bbep.println(string1);
-        String string2 = "Connect your phone or computer to ";
-        string2 += (message.length() > 0) ? "\"" + message + "\"" : String("the TRMNL");
-        string2 += " Wi-Fi";
+        String string2 = "Connect your phone or computer to:";
         bbep.getStringBox(string2, &rect);
 #ifdef __BB_EPAPER__
-        bbep.setCursor((bbep.width() - rect.w) / 2, 386);
+        bbep.setCursor((bbep.width() - rect.w) / 2, bbep.height() - (iFontHeight*4));
 #else
         bbep.setCursor((bbep.width() - rect.w) / 2, bbep.height() - 100 - rect.h);
 #endif
+        bbep.println(string2);
+        string2 = (message.length() > 0) ? "\"" + message + "\"" : String("the TRMNL");
+        string2 += " Wi-Fi";
+        bbep.getStringBox(string2, &rect);
+        bbep.setCursor((bbep.width() - rect.w) / 2, -1);
         bbep.println(string2);
         const char string3[] = "or scan the QR code for help";
         bbep.getStringBox(string3, &rect);


### PR DESCRIPTION
This change adds support for the Crowpanel 4.2" e-paper device. It required some changes to bb_epaper. It also required some changes to the TRMNL message display logic to properly display messages on the small (400x300) panel.
