### PR TITLE
Fixes battery info for the Waveshare 3.97 

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -134,7 +134,7 @@
 
 // Battery measurement types
 // BATT_NONE = use fake voltage
-enum { BATT_NONE = 0, BATT_ADC, BATT_BQ27220, BATT_BQ27427 };
+enum { BATT_NONE = 0, BATT_ADC, BATT_BQ27220, BATT_BQ27427, BATT_AXP2101 };
 
 #ifdef PARALLEL_EPD
 // TRMNL Device structure (slightly different for parallel eink panels)

--- a/platformio.ini
+++ b/platformio.ini
@@ -787,7 +787,7 @@ build_flags =
 		-D DEVICE_MODEL=\"waveshare_397\"
 		-D MINI_EPD2
 ;		-D DEV_FIRMWARE
-;       -D DO_NOT_LIGHT_SLEEP
+        -D DO_NOT_LIGHT_SLEEP
 ;        -D WAIT_FOR_SERIAL=1
 ;        -D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 ;        -D ARDUINO_USB_MODE=1

--- a/src/battery/adc_battery.cpp
+++ b/src/battery/adc_battery.cpp
@@ -48,6 +48,12 @@ float ADCBattery::readVoltage(TRMNL_DEVICE *pDevice) {
     Wire.begin(pDevice->sensor_sda, pDevice->sensor_scl);
     int16_t sensorValue = readReg16(0x55, 8); // current battery voltage in millivolts (registers 8+9)
     return (float)sensorValue / 1000.0f;
+  } else if (pDevice->batt_type == BATT_AXP2101) {
+    Wire.begin(pDevice->sensor_sda, pDevice->sensor_scl);
+    int16_t sensorValue = readReg16(0x34, 0x34); // current battery voltage in millivolts (registers 0x34+0x35)
+    sensorValue = __builtin_bswap16(sensorValue); // this chip is big-endian
+    sensorValue &= 0x3fff; // top 2 bits are config info
+    return (float)sensorValue / 1000.0f;
   } else { // BQ2742x
     Wire.begin(pDevice->sensor_sda, pDevice->sensor_scl);
     int16_t sensorValue = readReg16(0x55, 4); // current battery voltage in millivolts (registers 4+5)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -50,7 +50,7 @@ const TRMNL_DEVICE device_list[] =
   "og_gen2_4clr",  6,    1,     4,   2,    5,   0,    11,   12,   3,     0xff, 0xff,    BATT_BQ27427,  EPD_75_4CLR, // fake battery == 0xff
   "xteink_x4",     8,    10,    21,  5,    4,   6,    0xff, 0xff, 3,     0,    0xff,    BATT_ADC,  EPD_426,
   "waveshare",     13,   14,    15,  26,   27,  25,   0xff, 0xff, 33,    0xff, 0xff,    BATT_ADC,  EPD_75,
-  "waveshare_397", 11,   12,    10,  46,   9,   3,    41,   42,   0,     0xff, 0xff,    BATT_ADC,  EPD_397,
+  "waveshare_397", 11,   12,    10,  46,   9,   3,    41,   42,   0,     0xff, 0xff,    BATT_AXP2101,  EPD_397,
   "seeed_sticky",  13,   14,    15,  17,   16,  18,   1,    0,    4,     0xff, 0xff,    BATT_BQ27220,  EPD_397,  
   "seeed_esp32c3", 8,    10,    3,   2,    5,   4,    0xff, 0xff, 9,     0xff, 0xff,    BATT_ADC,  EPD_75,
   "seeed_esp32s3", 7,    9,     2,   1,    4,   3,    0xff, 0xff, 0,     0xff, 0xff,    BATT_ADC,  EPD_75,


### PR DESCRIPTION
This PR fixes reading the battery voltage level of the Waveshare 3.97" e-Paper ESP32-S3 device by adding support to read the voltage from the AXP2101 PMIC. This AXP2101 support can be used with other devices as needed.