### PR TITLE
Fix null pDevice crash when NVS is blank

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -175,6 +175,9 @@ void hw_config_init(void)
  */
 void display_init(void)
 {
+    if (pDevice == NULL) {
+        hw_config_init();
+    }
     Log_info("dev module start");
     iTempProfile = preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT);
     Log_info("Saved temperature profile: %" PRIu32, iTempProfile);


### PR DESCRIPTION
Found while flashing via `/flash/custom`, which writes a full image at `0x0` and wipes NVS. With `ship_done` cleared, `setup()` takes the `!isShipped` branch and calls `display_init()` before `bl_init()`, where `pDevice` is still NULL and the device crashes with LoadProhibited.

```
I (412) boot: Loaded app from partition at offset 0x20000
I (412) boot: Disabling RNG early entropy source...

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x4200b189  PS      : 0x00060f30  A0      : 0x8200dfae  A1      : 0x3fcebd80
A2      : 0x00000000  A3      : 0x0000002c  A4      : 0x0000002b  A5      : 0x3fca5bdc
A6      : 0x3fca5afc  A7      : 0x3c122c20  A8      : 0x00000000  A9      : 0x3fcebd20
A10     : 0x00000001  A11     : 0x00000001  A12     : 0x00000000  A13     : 0x000000b8
A14     : 0x3fcec304  A15     : 0x3fcec100  SAR     : 0x0000001a  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000004  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffff8

Backtrace: 0x4200b186:0x3fcebd80 0x4200dfab:0x3fcebda0 0x42059aee:0x3fcebe30

ELF file SHA256: 35e6fc2a4

Rebooting...
```

This will also happen when 1.8.17 is flashed on a fresh board or if user attempts to flash the FW via `/flash` page as it would then satisfy the same conditions. 