### PR TITLE
Added purging of cached images which are no longer in the playlist

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -11,6 +11,13 @@
 void filesystem_purge_old_file(const char *name);
 
 /**
+ * @brief Function to delete cached plugin images which are no longer in the playlist
+ * @param names the playlist image names separated by '|', empty when the playlist is empty
+ * @return nothing
+ */
+void filesystem_purge_unlisted_images(const char *names);
+
+/**
  * @brief Function to read a file into a newly allocated buffer
  * @param name filename
  * @param out_buffer pointer to pointer of the output buffer

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -46,6 +46,8 @@ struct ApiDisplayResponse {
   SPECIAL_FUNCTION special_function;
   String action;
   String touchbar_mode;
+  bool has_playlist_image_names; // false when the server didn't send the list (older server or a system screen)
+  String playlist_image_names; // names separated by '|' e.g. plugin-1a2b3c|mashup-4d5e6f
 };
 
 struct ApiDisplayInputs {

--- a/lib/trmnl/include/string_utils.h
+++ b/lib/trmnl/include/string_utils.h
@@ -9,3 +9,7 @@ void format_message_truncated(char *buffer, int max_size, const char *format, va
 // Escape special characters (\,") for use inside quoted ESP-AT string parameter.
 // https://docs.espressif.com/projects/esp-at/en/latest/esp32/AT_Command_Set/index.html
 String escape_modem_param(const String &param);
+
+// Returns true if the cached image path (e.g. /plugin-1a2b3c-1771674964) starts with one of the
+// playlist image names (separated by '|') sent by the server.
+bool playlist_has_image(const char *path, const char *names);

--- a/lib/trmnl/src/parse_response_api_display.cpp
+++ b/lib/trmnl/src/parse_response_api_display.cpp
@@ -26,7 +26,9 @@ ApiDisplayResponse parseResponse_apiDisplay(String &payload) {
         .reset_firmware = false,
         .special_function = SF_NONE,
         .action = "",
-        .touchbar_mode = ""};
+        .touchbar_mode = "",
+        .has_playlist_image_names = false,
+        .playlist_image_names = ""};
   }
   String special_function_str = doc["special_function"];
   // Convert the temperature profile ("default", "a", "b", "c")
@@ -38,6 +40,15 @@ ApiDisplayResponse parseResponse_apiDisplay(String &payload) {
   else if (tp == "b")
     u32TP = 2;
 //     else if (tp == "c") u32TP = 3;
+
+  // The playlist image names arrive as a JSON array; join them with '|' like the playlist order stored in NVS
+  JsonArray names = doc["playlist_image_names"];
+  String playlist_image_names = "";
+  int i, iCount = names.size();
+  for (i = 0; i < iCount; i++) {
+    if (i > 0) playlist_image_names += '|';
+    playlist_image_names += names[i].as<const char *>();
+  }
 
   return ApiDisplayResponse{
       .outcome = ApiDisplayOutcome::Ok,
@@ -55,5 +66,7 @@ ApiDisplayResponse parseResponse_apiDisplay(String &payload) {
       .reset_firmware = doc["reset_firmware"],
       .special_function = parseSpecialFunction(special_function_str),
       .action = doc["action"] | "",
-      .touchbar_mode = doc["touchbar_mode"] | ""};
+      .touchbar_mode = doc["touchbar_mode"] | "",
+      .has_playlist_image_names = doc["playlist_image_names"].is<JsonArray>(),
+      .playlist_image_names = playlist_image_names};
 }

--- a/lib/trmnl/src/string_utils.cpp
+++ b/lib/trmnl/src/string_utils.cpp
@@ -9,6 +9,21 @@ void format_message_truncated(char *buffer, int max_size, const char *format, va
   }
 }
 
+bool playlist_has_image(const char *path, const char *names) {
+  const char *s = names;
+  int iLen;
+
+  path++; // skip the leading '/'
+  while (*s) {
+    iLen = strcspn(s, "|");
+    if (strncmp(path, s, iLen) == 0 && path[iLen] == '-') // the name is followed by the timestamp
+      return true;
+    s += iLen;
+    if (*s == '|') s++;
+  }
+  return false;
+} /* playlist_has_image() */
+
 String escape_modem_param(const String &param) {
   String escaped = param;
     // Backslash first, so it doesn't re-escape the backslashes added below.

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1532,6 +1532,8 @@ static https_request_err_e downloadAndShow()
     filesystem_fix_filename(apiDisplayResult.response.filename.c_str(), szTemp);
     Log_info("Modem: saving to %s", szTemp);
     filesystem_purge_old_file(szTemp);
+    if (apiDisplayResult.response.has_playlist_image_names)
+      filesystem_purge_unlisted_images(apiDisplayResult.response.playlist_image_names.c_str());
 
     String _prevPath = preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "");
     String _prevLastPath = preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
@@ -1786,6 +1788,8 @@ static https_request_err_e downloadAndShow()
             filesystem_fix_filename(apiDisplayResult.response.filename.c_str(), szTemp);
             Log.info("%s [%d]: Writing %s to SPIFFS\r\n", __FILE__, __LINE__, szTemp);
             filesystem_purge_old_file(szTemp); // try to delete the old version or older than 24h
+            if (apiDisplayResult.response.has_playlist_image_names)
+              filesystem_purge_unlisted_images(apiDisplayResult.response.playlist_image_names.c_str());
             writeImageToFile(szTemp, buffer, content_size);
             Log.info("%s [%d]: Decoding %s\r\n", __FILE__, __LINE__, (isPNG) ? "png" : "jpeg");
             display_show_image(buffer, content_size, true);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <filesystem.h>
 #include <inttypes.h>
+#include <string_utils.h>
 #include <trmnl_log.h>
 
 #if defined(PARALLEL_EPD)
@@ -151,6 +152,35 @@ void filesystem_purge_old_file(const char *name) {
   rootDir.close();
 
 } /* filesystem_purge_old_file() */
+
+/**
+ * @brief Function to delete cached plugin images which are no longer in the playlist
+ *        The server sends the name of every image in the playlist (e.g. plugin-1a2b3c) and
+ *        any timestamped image not on that list gets deleted. Files without a timestamp
+ *        (setup logo, last displayed image) are left alone.
+ * @param names the playlist image names separated by '|', empty when the playlist is empty
+ * @return nothing
+ */
+void filesystem_purge_unlisted_images(const char *names) {
+  File rootDir;
+  char szTemp[36];
+
+  rootDir = FS.open("/");
+  while (File file = rootDir.openNextFile()) {
+    if (file.isDirectory() || filesystem_extract_timestamp(file.name()) == 0) {
+      file.close();
+      continue;
+    }
+    strcpy(szTemp, "/"); // needed on this file operation
+    strcat(szTemp, file.name());
+    file.close();
+    if (!playlist_has_image(szTemp, names)) {
+      Log_info("Deleting image no longer in the playlist - %s", szTemp);
+      FS.remove(szTemp);
+    }
+  }
+  rootDir.close();
+} /* filesystem_purge_unlisted_images() */
 
 /**
  * @brief Function to write data to file

--- a/test/test_parse_api_display/api_display.test.cpp
+++ b/test/test_parse_api_display/api_display.test.cpp
@@ -58,6 +58,32 @@ void test_parseResponse_apiDisplay_missing_fields(void) {
   assert_response_equal(expected, parseResponse_apiDisplay(input));
 }
 
+void test_parseResponse_apiDisplay_playlist_image_names(void) {
+  String input = "{\"status\":0,\"playlist_image_names\":[\"plugin-1a2b3c\",\"mashup-4d5e6f\"]}";
+
+  ApiDisplayResponse actual = parseResponse_apiDisplay(input);
+
+  TEST_ASSERT_TRUE(actual.has_playlist_image_names);
+  TEST_ASSERT_EQUAL_STRING("plugin-1a2b3c|mashup-4d5e6f", actual.playlist_image_names.c_str());
+}
+
+void test_parseResponse_apiDisplay_empty_playlist_image_names(void) {
+  String input = "{\"status\":0,\"playlist_image_names\":[]}";
+
+  ApiDisplayResponse actual = parseResponse_apiDisplay(input);
+
+  TEST_ASSERT_TRUE(actual.has_playlist_image_names);
+  TEST_ASSERT_EQUAL_STRING("", actual.playlist_image_names.c_str());
+}
+
+void test_parseResponse_apiDisplay_no_playlist_image_names(void) {
+  String input = "{\"status\":0}";
+
+  ApiDisplayResponse actual = parseResponse_apiDisplay(input);
+
+  TEST_ASSERT_FALSE(actual.has_playlist_image_names);
+}
+
 void test_parseResponse_apiDisplay_treats_unknown_sf_as_none(void) {
   String input = "{\"status\":200,\"image_url\":\"http://example.com/"
                  "foo.bmp\",\"update_firmware\":true,\"firmware_url\":\"https://example.com/"
@@ -82,6 +108,9 @@ void process() {
   RUN_TEST(test_parseResponse_apiDisplay_deserializationError);
   RUN_TEST(test_parseResponse_apiDisplay_treats_unknown_sf_as_none);
   RUN_TEST(test_parseResponse_apiDisplay_missing_fields);
+  RUN_TEST(test_parseResponse_apiDisplay_playlist_image_names);
+  RUN_TEST(test_parseResponse_apiDisplay_empty_playlist_image_names);
+  RUN_TEST(test_parseResponse_apiDisplay_no_playlist_image_names);
   UNITY_END();
 }
 

--- a/test/test_string_utils/string_utils.test.cpp
+++ b/test/test_string_utils/string_utils.test.cpp
@@ -69,6 +69,22 @@ void test_escape_all_special_chars_combined(void) {
 
 void test_escape_multiple_commas(void) { TEST_ASSERT_EQUAL_STRING("a\\,b\\,c", escape_modem_param("a,b,c").c_str()); }
 
+void test_playlist_has_image_matches_a_listed_name(void) {
+  TEST_ASSERT_TRUE(playlist_has_image("/mashup-4d5e6f-1771674964", "plugin-1a2b3c|mashup-4d5e6f"));
+}
+
+void test_playlist_has_image_rejects_an_unlisted_name(void) {
+  TEST_ASSERT_FALSE(playlist_has_image("/plugin-abcdef-1771674964", "plugin-1a2b3c|mashup-4d5e6f"));
+}
+
+void test_playlist_has_image_needs_the_whole_name(void) {
+  TEST_ASSERT_FALSE(playlist_has_image("/plugin-1a2b3c-1771674964", "plugin-1a2b|plugin-1a2b3c99"));
+}
+
+void test_playlist_has_image_rejects_everything_for_an_empty_list(void) {
+  TEST_ASSERT_FALSE(playlist_has_image("/plugin-1a2b3c-1771674964", ""));
+}
+
 void setUp(void) {
     // set stuff up here
 }
@@ -91,6 +107,10 @@ void process() {
   RUN_TEST(test_escape_backslash_before_comma);
   RUN_TEST(test_escape_all_special_chars_combined);
   RUN_TEST(test_escape_multiple_commas);
+  RUN_TEST(test_playlist_has_image_matches_a_listed_name);
+  RUN_TEST(test_playlist_has_image_rejects_an_unlisted_name);
+  RUN_TEST(test_playlist_has_image_needs_the_whole_name);
+  RUN_TEST(test_playlist_has_image_rejects_everything_for_an_empty_list);
   UNITY_END();
 }
 


### PR DESCRIPTION
The server now sends the name of every image in the device's playlist (playlist_image_names) with each API display response. After the usual 24h purge and before the new image is written, any timestamped image whose name is not on that list gets deleted, so an image leaves the device on the next check-in after its item leaves the playlist instead of sitting there for up to 24h. Files without a timestamp (setup logo, last displayed image) are left alone as before, and a response without the list (older server, system screens) changes nothing.